### PR TITLE
Fix ABRT/libreport config for blivet-gui

### DIFF
--- a/blivet-gui_event.conf
+++ b/blivet-gui_event.conf
@@ -1,4 +1,4 @@
-EVENT=notify pkg_name=blivet-gui
+EVENT=notify component=blivet-gui
     # Copy log files of crashed process
     cp /var/log/blivet-gui/blivet.log blivet.log
     cp /var/log/blivet-gui/program.log program.log


### PR DESCRIPTION
We can't use "pkg_name" because of splitting the package into
"blivet-gui" and "blivet-gui-runtime".