### PR TITLE
Do not try to teardown luks devices before removing (#1466940)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -545,19 +545,6 @@ class BlivetUtils(object):
         # for encrypted partitions/lvms delete the luks-formatted partition too
         if blivet_device.type in ("luks/dm-crypt",):
             for parent in blivet_device.parents:
-
-                if parent.exists:  # teardown existing parent before
-                    try:
-                        parent.teardown()
-
-                    except blivet.errors.LUKSError:
-                        msg = _("Failed to remove device {name}. Are you sure it's not in use?").format(name=parent.name)
-
-                        # cancel destroy action for luks device
-                        self.blivet_cancel_actions(actions)
-                        return ProxyDataContainer(success=False, actions=None, message=msg, exception=None,
-                                                  traceback=traceback.format_exc())
-
                 result = self.delete_device(parent, False)
                 if not result.success:
                     return result


### PR DESCRIPTION
We do not want to call teardown when scheduling the destroy action,
there may still be some active/existing children scheduled for
destroying and running "luksClose" will fail because of that.
Blivet also calls teardown() in _pre_destroy so this definitely
isn't needed.