### PR TITLE
Allow changing partition table (disklabel)

### DIFF
--- a/blivetgui/actions_menu.py
+++ b/blivetgui/actions_menu.py
@@ -47,7 +47,8 @@ class ActionsMenu(object):
                  ("decrypt", self.blivet_gui.decrypt_device),
                  ("info", self.blivet_gui.device_information),
                  ("parents", self.blivet_gui.edit_lvmvg),
-                 ("mountpoint", self.blivet_gui.set_mountpoint)]
+                 ("mountpoint", self.blivet_gui.set_mountpoint),
+                 ("partitiontable", self.blivet_gui.set_partition_table)]
 
         for item in items:
             menu_item = self.blivet_gui.builder.get_object("menuitem_" + item[0])

--- a/blivetgui/actions_toolbar.py
+++ b/blivetgui/actions_toolbar.py
@@ -69,7 +69,8 @@ class DeviceToolbar(BlivetGUIToolbar):
                  ("decrypt", "clicked", self.blivet_gui.decrypt_device),
                  ("info", "clicked", self.blivet_gui.device_information),
                  ("parents", "activate", self.blivet_gui.edit_lvmvg),
-                 ("mountpoint", "activate", self.blivet_gui.set_mountpoint)]
+                 ("mountpoint", "activate", self.blivet_gui.set_mountpoint),
+                 ("partitiontable", "activate", self.blivet_gui.set_partition_table)]
 
         for item in items:
             menu_item = self.blivet_gui.builder.get_object("button_" + item[0])

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -341,6 +341,13 @@ class BlivetGUI(object):
         dialog.destroy()
         return
 
+    def set_partition_table(self, _widget=None):
+        """ Create partition table on selected disk
+        """
+
+        device = self.list_partitions.selected_partition[0]
+        self._add_disklabel(device.disk)
+
     def _allow_add_device(self, selected_device):
         """ Allow add device?
         """

--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -199,6 +199,22 @@ class ListPartitions(object):
 
         return device.format.mountable
 
+    def _allow_set_partition_table(self, device):
+        # there is no special "device" representing disks in the UI
+        # so we are "editting" a free space
+        if device.type != "free space":
+            return False
+
+        # empty disk without disklabel
+        if device.is_uninitialized_disk:
+            return True
+
+        # empty disk with disklabel
+        if device.is_empty_disk and device.disk.format.type == "disklabel":
+            return True
+
+        return False
+
     def _allow_add_device(self, device):
         if device.protected:
             return False
@@ -247,6 +263,9 @@ class ListPartitions(object):
 
         if self._allow_set_mountpoint(device):
             self.blivet_gui.activate_device_actions(["mountpoint"])
+
+        if self._allow_set_partition_table(device):
+            self.blivet_gui.activate_device_actions(["partitiontable"])
 
         if device.type == "lvmvg":
             self.blivet_gui.activate_device_actions(["parents"])

--- a/data/ui/blivet-gui.ui
+++ b/data/ui/blivet-gui.ui
@@ -67,6 +67,14 @@
                 <property name="use_underline">True</property>
               </object>
             </child>
+            <child>
+              <object class="GtkMenuItem" id="menuitem_partitiontable">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Set partition table</property>
+                <property name="use_underline">True</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>
@@ -128,6 +136,14 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="label" translatable="yes">Set mountpoint</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="button_partitiontable">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Set partition table</property>
         <property name="use_underline">True</property>
       </object>
     </child>


### PR DESCRIPTION
This adds a new option to the "edit" menu. It uses the same
dialog as adding a new disklabel to an unitialized disk.