### PR TITLE
AddDialog: Fix displaying filesystem label entry

### DIFF
--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -755,16 +755,18 @@ class AddDialog(Gtk.Dialog):
 
     def on_filesystems_combo_changed(self, _combo):
 
-        if self.selected_fs is None or not self.selected_fs.mountable:
+        if self.selected_fs is None:
             self.hide_widgets(["label", "mountpoint"])
-
         else:
-            device_type = self.selected_type
-
-            if device_type in ("partition", "mdraid", "lvmlv", "lvmthinlv"):
-                self.show_widgets(["label", "mountpoint"])
+            if not self.selected_fs.mountable:
+                self.hide_widgets(["mountpoint"])
             else:
                 self.show_widgets(["mountpoint"])
+
+            if not self.selected_fs.labeling():
+                self.hide_widgets(["label"])
+            else:
+                self.show_widgets(["label"])
 
         # update size
         self.size_area.min_size_limit = self._get_min_size_limit()

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -471,9 +471,15 @@ class AddDialogTest(unittest.TestCase):
         add_dialog = AddDialog(self.parent_window, parent_device, free_device,
                                [("free", free_device)], [], True)  # with installer_mode=True
 
-        # swap -- mountpoint and label entries shouldn't be visible
+        # swap -- mountpoint entry shouldn't be visible, label entry should be visible
         add_dialog.filesystems_combo.set_active_id("swap")
         self.assertEqual(add_dialog.filesystems_combo.get_active_id(), "swap")
+        self.assertFalse(add_dialog.mountpoint_entry.get_visible())
+        self.assertTrue(add_dialog.label_entry.get_visible())
+
+        # lvmpv -- both mountpoint and label entries shouldn't be visible
+        add_dialog.filesystems_combo.set_active_id("lvmpv")
+        self.assertEqual(add_dialog.filesystems_combo.get_active_id(), "lvmpv")
         self.assertFalse(add_dialog.mountpoint_entry.get_visible())
         self.assertFalse(add_dialog.label_entry.get_visible())
 


### PR DESCRIPTION
Use "DeviceFormat.labeling" method to check if selected filesystem
supports labels.