### PR TITLE
Get supported filesystems in the 'backend' process

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -1250,6 +1250,25 @@ class BlivetUtils(object):
 
         return list(self.storage.mountpoints.keys())
 
+    def get_supported_filesystems(self, installer_mode=False):
+        _fs_types = []
+
+        additional_fs = ["swap", "lvmpv"]
+        if installer_mode:
+            additional_fs.extend(["biosboot", "prepboot"])
+
+        for cls in blivet.formats.device_formats.values():
+            obj = cls()
+
+            supported_fs = (obj.type not in ("tmpfs",) and
+                            obj.supported and obj.formattable and
+                            (isinstance(obj, blivet.formats.fs.FS) or
+                             obj.type in additional_fs))
+            if supported_fs:
+                _fs_types.append(obj)
+
+        return sorted(_fs_types, key=lambda fs: fs.type)
+
     def create_disk_label(self, blivet_device, label_type):
         """ Create disklabel
 

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -81,6 +81,9 @@ class BlivetGUI(object):
         # are not installed and that should be enough.
         fs.NTFS._supported = True
 
+        # supported filesystems
+        self._supported_filesystems = []
+
         # CSS styles
         css_provider = Gtk.CssProvider()
         css_provider.load_from_path(locate_css_file("rectangle.css"))
@@ -143,6 +146,15 @@ class BlivetGUI(object):
         self.exc.allow_ignore = True
 
         self.initialize()
+
+    @property
+    def supported_filesystems(self):
+        if self._supported_filesystems:
+            return self._supported_filesystems
+
+        self._supported_filesystems = self.client.remote_call("get_supported_filesystems",
+                                                              self.installer_mode)
+        return self._supported_filesystems
 
     def initialize(self):
         self.list_devices.load_devices()
@@ -291,6 +303,7 @@ class BlivetGUI(object):
 
         dialog = edit_dialog.FormatDialog(main_window=self.main_window,
                                           edit_device=device,
+                                          supported_filesystems=self.supported_filesystems,
                                           mountpoints=mountpoints,
                                           installer_mode=self.installer_mode)
 
@@ -439,6 +452,7 @@ class BlivetGUI(object):
                                       selected_parent=selected_parent,
                                       selected_free=selected_free,
                                       available_free=self.client.remote_call("get_free_info"),
+                                      supported_filesystems=self.supported_filesystems,
                                       mountpoints=mountpoints,
                                       installer_mode=self.installer_mode)
 

--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -40,7 +40,7 @@ from ..communication.proxy_utils import ProxyDataContainer
 
 from . size_chooser import SizeArea
 from .widgets import RaidChooser
-from .helpers import is_name_valid, is_label_valid, is_mountpoint_valid, supported_raids, supported_filesystems, get_monitor_size
+from .helpers import is_name_valid, is_label_valid, is_mountpoint_valid, supported_raids, get_monitor_size
 
 from ..i18n import _
 from ..config import config
@@ -237,7 +237,8 @@ class AddDialog(Gtk.Dialog):
          size, fs, label etc.
     """
 
-    def __init__(self, parent_window, selected_parent, selected_free, available_free, mountpoints=None, installer_mode=False):
+    def __init__(self, parent_window, selected_parent, selected_free, available_free,
+                 supported_filesystems, mountpoints=None, installer_mode=False):
         """
 
             :param str parent_type: type of (future) parent device
@@ -263,6 +264,7 @@ class AddDialog(Gtk.Dialog):
         self.installer_mode = installer_mode
         self.mountpoints = mountpoints
 
+        self.supported_filesystems = supported_filesystems
         self.supported_raids = supported_raids()
 
         Gtk.Dialog.__init__(self)
@@ -756,15 +758,14 @@ class AddDialog(Gtk.Dialog):
     def update_fs_chooser(self):
         self.filesystems_store.clear()
 
-        supported_fs = supported_filesystems(self.installer_mode)
-        for fs in supported_fs:
+        for fs in self.supported_filesystems:
             # FIXME: also check raid level -- resulting "free space" might be lower because of redundancy
             if self.selected_free.size > fs._min_size:
                 self.filesystems_store.append((fs, fs.type, fs.name))
         self.filesystems_store.append((None, "unformatted", _("unformatted")))
 
         # XXX: what if there is no supported fs?
-        if config.default_fstype in (fs.type for fs in supported_fs):
+        if config.default_fstype in (fs.type for fs in self.supported_filesystems):
             self.filesystems_combo.set_active_id(config.default_fstype)
         else:
             self.filesystems_combo.set_active(0)

--- a/blivetgui/dialogs/edit_dialog.py
+++ b/blivetgui/dialogs/edit_dialog.py
@@ -28,7 +28,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from .size_chooser import SizeChooser
-from .helpers import supported_filesystems, is_mountpoint_valid, is_label_valid
+from .helpers import is_mountpoint_valid, is_label_valid
 from ..dialogs import message_dialogs
 from ..gui_utils import locate_ui_file
 from ..communication.proxy_utils import ProxyDataContainer
@@ -121,9 +121,11 @@ class ResizeDialog(object):
 
 class FormatDialog(object):
 
-    def __init__(self, main_window, edit_device, mountpoints=None, installer_mode=False):
+    def __init__(self, main_window, edit_device, supported_filesystems,
+                 mountpoints=None, installer_mode=False):
         self.main_window = main_window
         self.edit_device = edit_device
+        self.supported_filesystems = supported_filesystems
         self.mountpoints = mountpoints
         self.installer_mode = installer_mode
 
@@ -145,8 +147,7 @@ class FormatDialog(object):
         self.label_entry = self.builder.get_object("entry_label")
         self.mnt_entry = self.builder.get_object("entry_mountpoint")
 
-        supported_fs = supported_filesystems(self.installer_mode)
-        for fs in supported_fs:
+        for fs in self.supported_filesystems:
             if self.edit_device.size > fs._min_size:
                 self.fs_store.append((fs, fs.type, fs.name))
         self.fs_store.append((None, "unformatted", _("unformatted")))
@@ -155,7 +156,7 @@ class FormatDialog(object):
         # triggering it for every format
         self.fs_combo.connect("changed", self._on_fs_combo_changed)
 
-        if config.default_fstype in (fs.type for fs in supported_fs):
+        if config.default_fstype in (fs.type for fs in self.supported_filesystems):
             self.fs_combo.set_active_id(config.default_fstype)
         else:
             self.fs_combo.set_active(0)

--- a/blivetgui/dialogs/helpers.py
+++ b/blivetgui/dialogs/helpers.py
@@ -31,7 +31,7 @@ gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk
 
-from blivet import devicefactory, formats
+from blivet import devicefactory
 # from blivet.devices.btrfs import BTRFSDevice
 # from blivet.devices.lvm import LVMVolumeGroupDevice, LVMLogicalVolumeDevice
 
@@ -162,23 +162,3 @@ def supported_raids():
     return {"btrfs volume": devicefactory.get_supported_raid_levels(devicefactory.DEVICE_TYPE_BTRFS),
             "mdraid": devicefactory.get_supported_raid_levels(devicefactory.DEVICE_TYPE_MD),
             "lvmlv": devicefactory.get_supported_raid_levels(devicefactory.DEVICE_TYPE_LVM)}
-
-
-def supported_filesystems(installer_mode=False):
-    _fs_types = []
-
-    additional_fs = ["swap", "lvmpv"]
-    if installer_mode:
-        additional_fs.extend(["biosboot", "prepboot"])
-
-    for cls in formats.device_formats.values():
-        obj = cls()
-
-        supported_fs = (obj.type not in ("tmpfs",) and
-                        obj.supported and obj.formattable and
-                        (isinstance(obj, formats.fs.FS) or
-                         obj.type in additional_fs))
-        if supported_fs:
-            _fs_types.append(obj)
-
-    return sorted(_fs_types, key=lambda fs: fs.type)

--- a/tests/blivetgui_tests/edit_dialog_test.py
+++ b/tests/blivetgui_tests/edit_dialog_test.py
@@ -12,8 +12,9 @@ from gi.repository import Gtk
 from blivet.size import Size
 
 from blivetgui.dialogs.edit_dialog import FormatDialog
-from blivetgui.dialogs.helpers import supported_filesystems
 from blivetgui.i18n import _
+
+from add_dialog_test import supported_filesystems
 
 
 @unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
@@ -22,10 +23,14 @@ class FormatDialogTest(unittest.TestCase):
     error_dialog = MagicMock()
     parent_window = Gtk.Window()
 
+    @classmethod
+    def setUpClass(cls):
+        cls.supported_filesystems = supported_filesystems()
+
     def test_basic(self):
 
         dev = MagicMock(size=Size("1 GiB"), format=MagicMock(mountpoint=None))
-        dialog = FormatDialog(self.parent_window, dev, [], False)
+        dialog = FormatDialog(self.parent_window, dev, self.supported_filesystems, [], False)
 
         # not installer_mode, mountpoint widgets should be invisible
         self.assertFalse(dialog.mnt_box.get_visible())
@@ -61,7 +66,7 @@ class FormatDialogTest(unittest.TestCase):
     def test_installer(self):
         dev = MagicMock(size=Size("1 GiB"), format=MagicMock(mountpoint=None))
 
-        dialog = FormatDialog(self.parent_window, dev, [], True)
+        dialog = FormatDialog(self.parent_window, dev, self.supported_filesystems, [], True)
 
         # ninstaller_mode, mountpoint widgets should be visible
         self.assertTrue(dialog.mnt_entry.get_visible())


### PR DESCRIPTION
A filesystem is "supported" only if we find tools to create it
in PATH but on some systems (e.g. Debian) /usr/sbin is not in PATH
for users so we need to obtain the list of supported filesystems
in the root process.