### PR TITLE
Don't pass 'hostname' kwarg to suggest_container_name (#1528103)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -785,7 +785,7 @@ class BlivetUtils(object):
                 else:
                     prefix = ""
 
-                name = self.storage.suggest_container_name(hostname=socket.gethostname(), prefix=prefix)
+                name = self.storage.suggest_container_name(prefix=prefix)
 
         else:
             name = self.storage.safe_device_name(name)


### PR DESCRIPTION
Since blivet commit 6a9f746a, this method doesn't accept a
'hostname' kwarg any more, so we can't pass one. This caused
any attempt to create some kind of container (VG, software
RAID set, etc) using blivet-gui to trigger a crash.

Signed-off-by: Adam Williamson <awilliam@redhat.com>