### PR TITLE
Ignore pylint 'no-value-for-parameter' warning

### DIFF
--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -88,7 +88,7 @@ class BlivetGUI(object):
         # CSS styles
         css_provider = Gtk.CssProvider()
         css_provider.load_from_path(locate_css_file("rectangle.css"))
-        screen = Gdk.Screen.get_default()
+        screen = Gdk.Screen.get_default()  # pylint: disable=no-value-for-parameter
         style_context = Gtk.StyleContext()
         style_context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
 

--- a/blivetgui/list_actions.py
+++ b/blivetgui/list_actions.py
@@ -47,7 +47,7 @@ class ListActions(object):
 
         self.blivet_gui = blivet_gui
 
-        icon_theme = Gtk.IconTheme.get_default()
+        icon_theme = Gtk.IconTheme.get_default()  # pylint: disable=no-value-for-parameter
         icon_add = Gtk.IconTheme.load_icon(icon_theme, "list-add", 16, 0)
         icon_delete = Gtk.IconTheme.load_icon(icon_theme, "edit-delete", 16, 0)
         icon_edit = Gtk.IconTheme.load_icon(icon_theme, "edit-select-all", 16, 0)

--- a/blivetgui/list_devices.py
+++ b/blivetgui/list_devices.py
@@ -65,7 +65,7 @@ class ListDevices(object):
         """ Load disks
         """
 
-        icon_theme = Gtk.IconTheme.get_default()
+        icon_theme = Gtk.IconTheme.get_default()  # pylint: disable=no-value-for-parameter
         icon_disk = Gtk.IconTheme.load_icon(icon_theme, "drive-harddisk", 32, 0)
         icon_disk_usb = Gtk.IconTheme.load_icon(icon_theme, "drive-removable-media", 32, 0)
 
@@ -95,7 +95,7 @@ class ListDevices(object):
 
         gdevices = self.blivet_gui.client.remote_call("get_group_devices")
 
-        icon_theme = Gtk.IconTheme.get_default()
+        icon_theme = Gtk.IconTheme.get_default()  # pylint: disable=no-value-for-parameter
         icon_group = Gtk.IconTheme.load_icon(icon_theme, "drive-multidisk", 32, 0)
 
         if gdevices["lvm"]:

--- a/blivetgui/osinstall.py
+++ b/blivetgui/osinstall.py
@@ -100,7 +100,7 @@ class BlivetGUIAnaconda(BlivetGUI):
         # CSS styles
         css_provider = Gtk.CssProvider()
         css_provider.load_from_path(locate_css_file("rectangle.css"))
-        screen = Gdk.Screen.get_default()
+        screen = Gdk.Screen.get_default()  # pylint: disable=no-value-for-parameter
         style_context = Gtk.StyleContext()
         style_context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
 

--- a/blivetgui/processing_window.py
+++ b/blivetgui/processing_window.py
@@ -92,7 +92,7 @@ class ProcessingActions(Gtk.Dialog):
         """ Show list of actions
         """
 
-        icon_theme = Gtk.IconTheme.get_default()
+        icon_theme = Gtk.IconTheme.get_default()  # pylint: disable=no-value-for-parameter
         icon_add = Gtk.IconTheme.load_icon(icon_theme, "list-add", 16, 0)
         icon_delete = Gtk.IconTheme.load_icon(icon_theme, "edit-delete", 16, 0)
         icon_edit = Gtk.IconTheme.load_icon(icon_theme, "edit-select-all", 16, 0)
@@ -129,7 +129,7 @@ class ProcessingActions(Gtk.Dialog):
         return actions_view, actions_list
 
     def _set_applied_icon(self, position):
-        icon_theme = Gtk.IconTheme.get_default()
+        icon_theme = Gtk.IconTheme.get_default()  # pylint: disable=no-value-for-parameter
         icon_applied = Gtk.IconTheme.load_icon(icon_theme, "emblem-ok-symbolic.symbolic", 16, 0)
 
         path = Gtk.TreePath(position)


### PR DESCRIPTION
Pylint thinks that some Gtk functions that doesn't expect any
parameters actually need a "self" parameter.