### PR TITLE
Ignore PEP8 W504 warning ("line break after binary operator")

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ pep8:
 	else \
 		echo "You need to install pep8 to run this check."; exit 1; \
 	fi ; \
-	$$pep8 --ignore=E501,E402,E731 blivetgui/ tests/ blivet-gui blivet-gui-daemon
+	$$pep8 --ignore=E501,E402,E731,W504 blivetgui/ tests/ blivet-gui blivet-gui-daemon
 
 canary:
 	$(MAKE) -C po potfile


### PR DESCRIPTION
PEP8 has changed and it now requires line breaks before a binary
operator instead after: https://hg.python.org/peps/rev/3857909d7956

Unfortunately older versions of pep8 still report it as warning
(W503) and we don't have a simple way how to ignore different
warnings based on pep8 version.