### PR TITLE
Do not show MD arrays in disks section

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -204,7 +204,7 @@ class BlivetUtils(object):
 
         """
 
-        return self.storage.disks
+        return (device for device in self.storage.disks if device.type != "mdarray")
 
     def get_group_devices(self):
         """ Return list of LVM2 Volume Group devices


### PR DESCRIPTION
In blivet MD arrays are disks, but we have a special category in
the UI, so we need to remove it here.