### PR TITLE
Fix suggesting names for btrfs subvolumes (#1648631)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -776,7 +776,11 @@ class BlivetUtils(object):
 
         if not name:
             if parent_device:
-                name = self.storage.suggest_device_name(parent=parent_device, swap=False)
+                # parent name is part of the child name only on LVM
+                if parent_device.type == "lvmvg":
+                    name = self.storage.suggest_device_name(parent=parent_device, swap=False)
+                else:
+                    name = self.storage.suggest_device_name(swap=False)
             elif snapshot:
                 name = self.storage.suggest_device_name(parent=parent_device, swap=False, prefix="snapshot")
             else:


### PR DESCRIPTION
'suggest_device_name' with 'parent' specified works only for LVM,
because LVM names are combination of VG name and LV name. For
btrfs subvolumes this results in a non-unique name recommendation.