### PR TITLE
Enable name validity checks in AddDialog (#1649364)

### DIFF
--- a/blivetgui/dialogs/helpers.py
+++ b/blivetgui/dialogs/helpers.py
@@ -32,9 +32,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from blivet import devicefactory
-# from blivet.devices.btrfs import BTRFSDevice
-# from blivet.devices.lvm import LVMVolumeGroupDevice, LVMLogicalVolumeDevice
-
+from blivet.devicelibs import btrfs, lvm
 from blivet.tasks.fslabeling import Ext2FSLabeling, FATFSLabeling, JFSLabeling, ReiserFSLabeling, XFSLabeling, NTFSLabeling
 
 # ---------------------------------------------------------------------------- #
@@ -97,17 +95,13 @@ def adjust_scrolled_size(scrolledwindow, width_limit, height_limit):
         scrolledwindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
 
-def is_name_valid(_device_type, _name):
-    # temporarily disabled because of changes in blivet
-    # if device_type in ("lvmvg", "lvm"):
-    #     return LVMVolumeGroupDevice.is_name_valid(name)
-    # elif device_type == "lvmlv":
-    #     return LVMLogicalVolumeDevice.is_name_valid(name)
-    # elif device_type in ("btrfs volume", "btrfs subvolume"):
-    #     return BTRFSDevice.is_name_valid(name)
-    # else:
-    #     return True
-    return True  # FIXME
+def is_name_valid(device_type, name):
+    if device_type in ("lvmvg", "lvm", "lvmlv"):
+        return lvm.is_lvm_name_valid(name)
+    elif device_type in ("btrfs volume", "btrfs subvolume"):
+        return btrfs.is_btrfs_name_valid(name)
+    else:
+        return True
 
 
 def is_label_valid(format_type, label):

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -657,7 +657,6 @@ class AddDialogTest(unittest.TestCase):
         self.error_dialog.reset_mock()
 
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
-    @unittest.skip("name validity check temporarily disabled")
     def test_name_validity_check(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)


### PR DESCRIPTION
This was disabled before because it was necessary to create the
Device object to check the name. This was changed and we can now
use devicelibs function.

This depends on https://github.com/storaged-project/blivet/pull/735