### PR TITLE
Fix return type of BlivetUtils.get_disks (#1658893)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -204,7 +204,7 @@ class BlivetUtils(object):
 
         """
 
-        return (device for device in self.storage.disks if device.type != "mdarray")
+        return [device for device in self.storage.disks if device.type != "mdarray"]
 
     def get_group_devices(self):
         """ Return list of LVM2 Volume Group devices


### PR DESCRIPTION
This must be a list, not a generator, because we are iterating
over it multiple times in some cases.