### PR TITLE
Use 'direct' device property to (dis)allow mountpoint selection

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -70,6 +70,7 @@ class RawFormatDevice(object):
         self.is_free_space = False
         self.is_disk = False
         self.isleaf = True
+        self.direct = True
 
         self.children = []
         self.parents = blivet.devices.lib.ParentList(items=[self.disk])
@@ -126,6 +127,7 @@ class FreeSpaceDevice(object):
         self.is_primary = not logical
         self.is_free_space = True
         self.is_disk = False
+        self.direct = False
 
         self.format = DeviceFormat(exists=True)
         self.type = "free space"

--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -197,11 +197,10 @@ class ListPartitions(object):
         if device.type in ("lvmthinsnapshot", "lvmsnapshot") and not device.exists:
             return False
 
-        # do not allow to set mountpoints for devices with children
+        # do not allow to set mountpoints for devices that are not "direct"
         # (e.g. partition formatted to btrfs -- the mountpoint must be set for
-        # the btrfs volume on top of it; btrfs volume itself is an exception --
-        # it is possible to set mountpoint for both volume and its subvolumes)
-        if device.children and device.type != "btrfs volume":
+        # the btrfs volume on top of it)
+        if not device.direct:
             return False
 
         return device.format.mountable


### PR DESCRIPTION
This is better solution for btrfs mountpoint problem originally
fixed in 402ef7d1165d6a609267b107b8fe6a503ec5ee0d