### PR TITLE
Count format minimal size when checking encrypted device min size

### DIFF
--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -925,10 +925,12 @@ class AddDialog(Gtk.Dialog):
     def on_encrypt_check(self, _toggle):
         if self.encrypt_check.get_active():
             self.show_widgets(["passphrase"])
-            self.update_size_area_limits(reserved_size=crypto.LUKS_METADATA_SIZE)
+            self.update_size_area_limits(min_size=self._get_min_size_limit(),
+                                         reserved_size=crypto.LUKS_METADATA_SIZE)
         else:
             self.hide_widgets(["passphrase"])
-            self.update_size_area_limits(reserved_size=size.Size(0))
+            self.update_size_area_limits(min_size=self._get_min_size_limit(),
+                                         reserved_size=size.Size(0))
 
     def on_passphrase_changed(self, confirm_entry, passphrase_entry):
         if passphrase_entry.get_text() == confirm_entry.get_text():


### PR DESCRIPTION
We still need to check min size limit for the device we are
creating to be sure to include the filesystem/format minimal size.
E.g. we need to set 10 MiB for lvmpv (2 MiB for LUKS metadata +
8 MiB for PV metadata).
This was discovered thanks to recent changes in blivet -- all
filesystems now have non-zero minimal size.