### PR TITLE
Mark E1121 pylint error as false positive in tests

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -9,10 +9,9 @@ class BlivetGUILintConfig(PocketLintConfig):
     def __init__(self):
         PocketLintConfig.__init__(self)
 
-        self.falsePositives = [FalsePositive(r"Context manager 'lock' doesn't implement __enter__ and __exit__"),
-                               FalsePositive(r"Value '.*\.parents_store' is unsubscriptable"),
+        self.falsePositives = [FalsePositive(r"Value '.*\.parents_store' is unsubscriptable"),
                                FalsePositive(r"Non-iterable value .*\.parents_store is used in an iterating context"),
-                               FalsePositive(r"Bad option value 'subprocess-popen-preexec-fn'")]
+                               FalsePositive(r".*Test\..*: Too many positional arguments for method call")]
 
     @property
     def pylintPlugins(self):


### PR DESCRIPTION
Unfortunately pylint still doesn't understand the new positional
only arguments syntax from Python 3.8 (PEP 570) and because Mock
is already using these pylint is failing on 3.8.

Also remove some old false positives that are no longer valid.