### PR TITLE
Explicitly disable return code check in subprocess.run

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -49,7 +49,7 @@ PARTITION_TYPE = {"primary": parted.PARTITION_NORMAL,
 
 def lsblk():
     p = subprocess.run(["lsblk", "-a", "-o", "+FSTYPE,LABEL,UUID,MOUNTPOINT"],
-                       stdout=subprocess.PIPE)
+                       stdout=subprocess.PIPE, check=False)
     return p.stdout.decode()
 
 


### PR DESCRIPTION
False is default but not setting this explicitly makes pylint
unhappy (W1510 subprocess-run-check).