### PR TITLE
Specify starting sector when creating partitions (#1755813)

### DIFF
--- a/tests/blivetutils_tests/blivetutilstestcase.py
+++ b/tests/blivetutils_tests/blivetutilstestcase.py
@@ -34,6 +34,9 @@ class BlivetUtilsTestToolkit(unittest.TestCase):
     def get_blivet_device(self, device_name):
         return self.blivet_utils.storage.devicetree.get_device_by_name(device_name)
 
+    def reset(self):
+        self.blivet_utils.blivet_reset()
+
 
 @unittest.skipUnless(os.geteuid() == 0, "requires root access")
 class BlivetUtilsTestCase(unittest.TestCase):


### PR DESCRIPTION
Sorting using weight unfortunately works only for non-existing
partitions and breaks if there is a preexisting partition in the
middle of the disk. The best way to be sure the partition is
always created in the correct free region selected from the GUI
seems to be specifying starting sector for each partition.
We also need to make sure the starting sector is correctly aligned
because blivet doesn't align partitions with the start sector set.
The alignment code is inspired by the `bd_part_create_part`
function from libblockdev and alignment code there.