### PR TITLE
Allow selection of encryption type (LUKS version)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -906,6 +906,7 @@ class BlivetUtils(object):
         if user_input.encrypt:
             part_fmt = blivet.formats.get_format(fmt_type="luks",
                                                  passphrase=user_input.passphrase,
+                                                 luks_version=user_input.encryption_type,
                                                  device=new_part.path)
             actions.append(blivet.deviceaction.ActionCreateFormat(new_part, part_fmt))
 
@@ -959,6 +960,7 @@ class BlivetUtils(object):
             if user_input.encrypt:
                 luks_fmt = blivet.formats.get_format(fmt_type="luks",
                                                      passphrase=user_input.passphrase,
+                                                     luks_version=user_input.encryption_type,
                                                      device=new_lv.path)
                 actions.append(blivet.deviceaction.ActionCreateFormat(new_lv, luks_fmt))
 
@@ -993,6 +995,7 @@ class BlivetUtils(object):
         if user_input.encrypt:
             part_fmt = blivet.formats.get_format(fmt_type="luks",
                                                  passphrase=user_input.passphrase,
+                                                 luks_version=user_input.encryption_type,
                                                  device=new_part.path)
             actions.append(blivet.deviceaction.ActionCreateFormat(new_part, part_fmt))
 
@@ -1045,7 +1048,8 @@ class BlivetUtils(object):
             size_selection = ProxyDataContainer(total_size=parent.selected_size, parents=[parent])
             pv_input = ProxyDataContainer(size_selection=size_selection,
                                           encrypt=user_input.encrypt,
-                                          passphrase=user_input.passphrase)
+                                          passphrase=user_input.passphrase,
+                                          luks_version=user_input.encryption_type)
             pv_actions = self._create_lvmpv(pv_input)
 
             # we need to try to register create actions immediately, if something fails, fail now
@@ -1119,6 +1123,7 @@ class BlivetUtils(object):
         if user_input.encrypt:
             luks_fmt = blivet.formats.get_format(fmt_type="luks",
                                                  passphrase=user_input.passphrase,
+                                                 luks_version=user_input.encryption_type,
                                                  device=new_md.path)
             actions.append(blivet.deviceaction.ActionCreateFormat(new_md, luks_fmt))
 

--- a/blivetgui/dialogs/helpers.py
+++ b/blivetgui/dialogs/helpers.py
@@ -32,7 +32,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from blivet import devicefactory
-from blivet.devicelibs import btrfs, lvm
+from blivet.devicelibs import btrfs, lvm, crypto
 from blivet.tasks.fslabeling import Ext2FSLabeling, FATFSLabeling, JFSLabeling, ReiserFSLabeling, XFSLabeling, NTFSLabeling
 
 # ---------------------------------------------------------------------------- #
@@ -156,3 +156,11 @@ def supported_raids():
     return {"btrfs volume": devicefactory.get_supported_raid_levels(devicefactory.DEVICE_TYPE_BTRFS),
             "mdraid": devicefactory.get_supported_raid_levels(devicefactory.DEVICE_TYPE_MD),
             "lvmlv": devicefactory.get_supported_raid_levels(devicefactory.DEVICE_TYPE_LVM)}
+
+
+def supported_encryption_types():
+    return crypto.LUKS_VERSIONS
+
+
+def default_encryption_type():
+    return crypto.DEFAULT_LUKS_VERSION

--- a/blivetgui/dialogs/size_chooser.py
+++ b/blivetgui/dialogs/size_chooser.py
@@ -30,7 +30,7 @@ from gi.repository import Gtk
 from blivet import size
 from blivet.devicelibs.raid import Single, Linear
 
-from .widgets import GUIWidget
+from .widgets import GUIWidget, SignalHandler
 from ..i18n import _
 from ..communication.proxy_utils import ProxyDataContainer
 
@@ -42,17 +42,6 @@ UNITS = OrderedDict([("B", size.B), ("KB", size.KB), ("MB", size.MB),
                      ("GB", size.GB), ("TB", size.TB), ("KiB", size.KiB),
                      ("MiB", size.MiB), ("GiB", size.GiB), ("TiB", size.TiB)])
 # ---------------------------------------------------------------------------- #
-
-
-class SignalHandler(ProxyDataContainer):
-
-    def __init__(self, method, args):
-        """
-            :param method: method/function that should be called
-            :param args: additional arguments for calling @method
-        """
-
-        super().__init__(method=method, args=args)
 
 
 class SizeSelection(ProxyDataContainer):

--- a/data/ui/encryption_chooser.ui
+++ b/data/ui/encryption_chooser.ui
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkGrid" id="grid">
+    <property name="name">grid</property>
+    <property name="width_request">400</property>
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_left">20</property>
+    <property name="margin_top">5</property>
+    <property name="row_spacing">10</property>
+    <property name="column_spacing">5</property>
+    <property name="column_homogeneous">True</property>
+    <child>
+      <object class="GtkLabel" id="label_encrypt">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">Encrypt:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label_type">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">Encryption type:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label_passphrase">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">Passphrase:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label_repeat">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">Repeat Passphrase:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="entry_passphrase">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="visibility">False</property>
+        <property name="invisible_char">●</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="entry_repeat">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="visibility">False</property>
+        <property name="invisible_char">●</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkComboBoxText" id="combobox_type">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="check_encrypt">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="draw_indicator">True</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/tests/blivetgui_tests/widgets_test.py
+++ b/tests/blivetgui_tests/widgets_test.py
@@ -3,9 +3,15 @@
 import os
 import unittest
 
-from blivet.devicelibs.raid import RAID0, RAID1, RAID5, Single, Linear
+import gi
+gi.require_version("Gtk", "3.0")
 
-from blivetgui.dialogs.widgets import RaidChooser
+from gi.repository import Gtk
+
+from blivet.devicelibs.raid import RAID0, RAID1, RAID5, Single, Linear
+from blivet.devicelibs import crypto
+from blivetgui.dialogs.widgets import RaidChooser, EncryptionChooser
+from blivetgui.i18n import _
 
 
 @unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
@@ -74,6 +80,74 @@ class RaidChooserTest(unittest.TestCase):
 
         chooser.selected_level = RAID1
         self.assertEqual(chooser.selected_level, RAID1)
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class EncryptionChooserTest(unittest.TestCase):
+
+    def test_encrypt_validity_check(self):
+        encrypt_chooser = EncryptionChooser()
+
+        # passphrases specified and matches
+        encrypt_chooser.encrypt = True
+        encrypt_chooser._passphrase_entry.set_text("aaaaa")
+        encrypt_chooser._repeat_entry.set_text("aaaaa")
+        succ, msg = encrypt_chooser.validate_user_input()
+        self.assertTrue(succ)
+        self.assertIsNone(msg)
+
+        # passphrases specified but don't match
+        encrypt_chooser.encrypt = True
+        encrypt_chooser._passphrase_entry.set_text("aaaaa")
+        encrypt_chooser._repeat_entry.set_text("bbbb")
+        succ, msg = encrypt_chooser.validate_user_input()
+        self.assertFalse(succ)
+        self.assertEqual(msg, _("Provided passphrases do not match."))
+
+        # no passphrase specified
+        encrypt_chooser.encrypt = True
+        encrypt_chooser._passphrase_entry.set_text("")
+        succ, msg = encrypt_chooser.validate_user_input()
+        self.assertFalse(succ)
+        self.assertEqual(msg, _("Passphrase not specified."))
+
+    def test_encryption_selection(self):
+        encrypt_chooser = EncryptionChooser()
+
+        encrypt_chooser.encrypt = True
+        encrypt_chooser._passphrase_entry.set_text("aaaaa")
+        encrypt_chooser._repeat_entry.set_text("aaaaa")
+
+        user_input = encrypt_chooser.get_selection()
+        self.assertEqual(user_input.encrypt, True)
+        self.assertEqual(user_input.passphrase, "aaaaa")
+        self.assertEqual(user_input.encryption_type, crypto.DEFAULT_LUKS_VERSION)
+
+    def test_encryption_chooser(self):
+        encrypt_chooser = EncryptionChooser()
+
+        encrypt_chooser.encrypt = True
+        self.assertTrue(encrypt_chooser._passphrase_entry.get_visible())
+        self.assertTrue(encrypt_chooser._repeat_entry.get_visible())
+
+        # check the encrypt check, passphrase entries should be hidden
+        encrypt_chooser.encrypt = False
+        self.assertFalse(encrypt_chooser._passphrase_entry.get_visible())
+        self.assertFalse(encrypt_chooser._repeat_entry.get_visible())
+
+    def test_passphrase_entry(self):
+        encrypt_chooser = EncryptionChooser()
+
+        encrypt_chooser.encrypt = True
+
+        # passphrases don't match -> error icon
+        encrypt_chooser._passphrase_entry.set_text("aa")
+        encrypt_chooser._repeat_entry.set_text("bb")
+        self.assertEqual(encrypt_chooser._repeat_entry.get_icon_name(Gtk.EntryIconPosition.SECONDARY), "dialog-error-symbolic.symbolic")
+
+        # passphrases match -> ok icon
+        encrypt_chooser._repeat_entry.set_text("aa")
+        self.assertEqual(encrypt_chooser._repeat_entry.get_icon_name(Gtk.EntryIconPosition.SECONDARY), "emblem-ok-symbolic.symbolic")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Blivet now supports both LUKS1 and LUKS2 so we should allow
choosing the "type" of encryption which will be used.

All "encryption" widgets from AddDialog were also moved to a new
EncryptionChooser widget.