### PR TITLE
Get default filesystem type from blivet

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -1319,6 +1319,9 @@ class BlivetUtils(object):
 
         return sorted(_fs_types, key=lambda fs: fs.type)
 
+    def get_default_filesystem(self):
+        return self.storage.default_fstype
+
     def create_disk_label(self, blivet_device, label_type):
         """ Create disklabel
 

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -50,6 +50,7 @@ from .processing_window import ProcessingActions
 from .loading_window import LoadingWindow
 from .exception_handler import BlivetGUIExceptionHandler
 from .communication.constants import ServerInitResponse
+from .config import config
 
 import threading
 import sys
@@ -145,6 +146,9 @@ class BlivetGUI(object):
 
         # allow ignoring exceptions
         self.exc.allow_ignore = True
+
+        # set some defaults from blivet now
+        config.default_fstype = self.client.remote_call("get_default_filesystem")
 
         self.initialize()
 

--- a/blivetgui/osinstall.py
+++ b/blivetgui/osinstall.py
@@ -42,6 +42,8 @@ from .dialogs import message_dialogs, constants
 from .i18n import _
 from .gui_utils import locate_ui_file, locate_css_file
 from .logs import set_logging
+from .config import config
+
 from blivet.errors import StorageError
 import sys
 from contextlib import contextmanager
@@ -138,6 +140,12 @@ class BlivetGUIAnaconda(BlivetGUI):
 
         self.physical_view = PhysicalView(self)
         self.builder.get_object("scrolledwindow_physical").add(self.physical_view.vbox)
+
+    def initialize(self):
+        super().initialize()
+
+        # set some defaults from blivet now
+        config.default_fstype = self.client.remote_call("get_default_filesystem")
 
     def ui_refresh(self, _spoke):
         """ This should be called only from Anaconda using the spoke 'entered'


### PR DESCRIPTION
Anaconda originally did this in the blivet-gui spoke but we need
to move all code that works with the Blivet instance to blivet-gui.

Fixes #139 