### PR TITLE
Fix displaying the exception dialog in Anaconda

### DIFF
--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -232,7 +232,7 @@ class BlivetGUI(object):
         self.device_toolbar.deactivate_all()
         self.popup_menu.deactivate_all()
 
-    def _reraise_exception(self, exception, traceback, message):
+    def _reraise_exception(self, exception, traceback, message, dialog_window=None):
         raise type(exception)(message + "\n" + str(exception) + "\n" + traceback)
 
     def show_error_dialog(self, error_message):
@@ -288,7 +288,8 @@ class BlivetGUI(object):
                 if not result.exception:
                     self.show_error_dialog(result.message)
                 else:
-                    self._reraise_exception(result.exception, result.traceback, message)
+                    self._reraise_exception(result.exception, result.traceback, message,
+                                            dialog_window=dialog.dialog)
             else:
                 if result.actions:
                     action_str = _("resize {name} {type}").format(name=device.name, type=device.type)
@@ -320,7 +321,8 @@ class BlivetGUI(object):
                 if not result.exception:
                     self.show_error_dialog(result.message)
                 else:
-                    self._reraise_exception(result.exception, result.traceback, message)
+                    self._reraise_exception(result.exception, result.traceback, message,
+                                            dialog_window=dialog.dialog)
             else:
                 if result.actions:
                     action_str = _("format {name} {type}").format(name=device.name, type=device.type)
@@ -347,7 +349,8 @@ class BlivetGUI(object):
                 if not result.exception:
                     self.show_error_dialog(result.message)
                 else:
-                    self._reraise_exception(result.exception, result.traceback, message)
+                    self._reraise_exception(result.exception, result.traceback, message,
+                                            dialog_window=dialog)
             else:
                 if result.actions:
                     action_str = _("edit {name} {type}").format(name=device.name, type=device.type)
@@ -407,7 +410,8 @@ class BlivetGUI(object):
                 if not result.exception:
                     self.show_error_dialog(result.message)
                 else:
-                    self._reraise_exception(result.exception, result.traceback, message)
+                    self._reraise_exception(result.exception, result.traceback, message,
+                                            dialog_window=dialog.dialog)
 
             else:
                 if result.actions:
@@ -473,7 +477,8 @@ class BlivetGUI(object):
                 if not result.exception:
                     self.show_error_dialog(result.message)
                 else:
-                    self._reraise_exception(result.exception, result.traceback, message)
+                    self._reraise_exception(result.exception, result.traceback, message,
+                                            dialog_window=dialog)
 
             else:
                 if result.actions:
@@ -523,7 +528,8 @@ class BlivetGUI(object):
                     self.show_error_dialog(result.message)
 
                 else:
-                    self._reraise_exception(result.exception, result.traceback, message)
+                    self._reraise_exception(result.exception, result.traceback, message,
+                                            dialog_window=dialog.dialog)
 
             else:
                 action_str = _("delete partition {name}").format(name=deleted_device.name)
@@ -568,7 +574,7 @@ class BlivetGUI(object):
                 message = _("Failed to perform the actions:")
                 dialog.destroy()
                 self.main_window.set_sensitive(False)
-                self._reraise_exception(error, traceback, message)  # pylint: disable=raising-bad-type
+                self._reraise_exception(error, traceback, message, dialog_window=dialog)  # pylint: disable=raising-bad-type
 
         def show_progress(message):
             dialog.progress_msg(message)
@@ -747,7 +753,8 @@ class BlivetGUI(object):
             # unknow problem --> re-raise exception
             else:
                 message = _("Failed to init blivet:")
-                self._reraise_exception(ret.exception, ret.traceback, message)
+                self._reraise_exception(ret.exception, ret.traceback, message,
+                                        dialog_window=loading_window)
 
     def _blivet_init_ignore(self, exception, device_name):
 

--- a/blivetgui/dialogs/message_dialogs.py
+++ b/blivetgui/dialogs/message_dialogs.py
@@ -101,7 +101,7 @@ class ExceptionDialog(object):
     """ Error dialog with traceback
     """
 
-    def __init__(self, parent_window, allow_ignore, allow_report, msg, traceback):
+    def __init__(self, parent_window, allow_ignore, allow_report, msg, traceback, decorated=True):
 
         self.allow_ignore = allow_ignore
         self.allow_report = allow_report
@@ -111,6 +111,7 @@ class ExceptionDialog(object):
         builder.add_from_file(locate_ui_file('exception_dialog.ui'))
         self.dialog = builder.get_object("exception_dialog")
 
+        self.dialog.set_decorated(decorated)
         self.dialog.set_transient_for(parent_window)
         self.dialog.format_secondary_text(msg)
 

--- a/blivetgui/osinstall.py
+++ b/blivetgui/osinstall.py
@@ -208,7 +208,7 @@ class BlivetGUIAnaconda(BlivetGUI):
 
         self.main_window.lightbox_off()
 
-    def _reraise_exception(self, exception, traceback, message):
+    def _reraise_exception(self, exception, traceback, message, dialog_window=None):
         allow_report = True
         allow_ignore = self.allow_ignore and issubclass(type(exception), StorageError)
         if allow_ignore:
@@ -216,9 +216,12 @@ class BlivetGUIAnaconda(BlivetGUI):
         else:
             msg = _("Unknown error occured. Anaconda will be terminated.\n{error}").format(error=str(exception))
 
-        dialog = message_dialogs.ExceptionDialog(self.main_window, allow_ignore,
-                                                 allow_report, msg, str(traceback))
-        response = dialog.run()
+        with self.enlightbox():
+            dialog = message_dialogs.ExceptionDialog(dialog_window if dialog_window else self.main_window,
+                                                     allow_ignore, allow_report,
+                                                     msg, str(traceback),
+                                                     decorated=False)
+            response = dialog.run()
 
         if response == constants.DialogResponseType.BACK:
             return


### PR DESCRIPTION
We need to make sure it's set to be always above the displayed
dialog and also to remove window decoration when running in the
installer environment.