### PR TITLE
Add a simple script to run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ RELEASE_TAG=$(VERSION)-$(RELEASE)
 ZANATA_PULL_ARGS = --transdir ./
 ZANATA_PUSH_ARGS = --srcdir ./ --push-type source --force
 PYTHON=python3
-COVERAGE=coverage3
 
 all:
 	$(MAKE) -C po
@@ -37,16 +36,11 @@ test:
 
 gui-test:
 	@echo "*** Running GUI tests ***"
-	PYTHONPATH=.:tests/ xvfb-run -s '-screen 0 640x480x8 -extension RANDR' $(PYTHON) -m unittest discover -v -s tests/blivetgui_tests -p '*_test.py'
+	PYTHONPATH=.:tests/ xvfb-run -s '-screen 0 640x480x8 -extension RANDR' $(PYTHON) tests/run_tests.py blivetgui_tests
 
 utils-test:
 	@echo "*** Running Utils tests ***"
-	PYTHONPATH=.:tests/ $(PYTHON) -m unittest discover -v -s tests/blivetutils_tests -p 'test_*.py'
-
-coverage:
-	@echo "*** Running unittests with $(COVERAGE) for $(PYTHON) ***"
-	PYTHONPATH=.:tests/ $(COVERAGE) run --branch -m unittest discover -v -s tests/ -p '*_test.py'
-	$(COVERAGE) report --include="blivetgui/*" --show-missing
+	PYTHONPATH=.:tests/ $(PYTHON) tests/run_tests.py blivetutils_tests
 
 pylint:
 	@echo "*** Running pylint ***"

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -8,11 +8,6 @@ from blivetgui.i18n import _
 
 import os
 
-import gi
-gi.require_version("Gtk", "3.0")
-
-from gi.repository import Gtk
-
 from blivet.size import Size
 from blivet import formats
 
@@ -234,10 +229,14 @@ class AdvancedOptionsTest(unittest.TestCase):
 class AddDialogTest(unittest.TestCase):
 
     error_dialog = MagicMock()
-    parent_window = Gtk.Window()
 
     @classmethod
     def setUpClass(cls):
+        import gi
+        gi.require_version("Gtk", "3.0")
+        from gi.repository import Gtk
+
+        cls.parent_window = Gtk.Window()
         cls.supported_filesystems = supported_filesystems()
 
     def _get_free_device(self, size=Size("8 GiB"), logical=False, parent=None, **kwargs):

--- a/tests/blivetgui_tests/edit_dialog_test.py
+++ b/tests/blivetgui_tests/edit_dialog_test.py
@@ -14,7 +14,7 @@ from blivet.size import Size
 from blivetgui.dialogs.edit_dialog import FormatDialog
 from blivetgui.i18n import _
 
-from add_dialog_test import supported_filesystems
+from .add_dialog_test import supported_filesystems
 
 
 @unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")

--- a/tests/blivetgui_tests/edit_dialog_test.py
+++ b/tests/blivetgui_tests/edit_dialog_test.py
@@ -4,11 +4,6 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-import gi
-gi.require_version("Gtk", "3.0")
-
-from gi.repository import Gtk
-
 from blivet.size import Size
 
 from blivetgui.dialogs.edit_dialog import FormatDialog
@@ -21,10 +16,14 @@ from .add_dialog_test import supported_filesystems
 class FormatDialogTest(unittest.TestCase):
 
     error_dialog = MagicMock()
-    parent_window = Gtk.Window()
 
     @classmethod
     def setUpClass(cls):
+        import gi
+        gi.require_version("Gtk", "3.0")
+        from gi.repository import Gtk
+
+        cls.parent_window = Gtk.Window()
         cls.supported_filesystems = supported_filesystems()
 
     def test_basic(self):

--- a/tests/blivetutils_tests/test_10_disks.py
+++ b/tests/blivetutils_tests/test_10_disks.py
@@ -4,7 +4,7 @@ import blivet
 
 from blivetgui.communication.proxy_utils import ProxyDataContainer
 
-from blivetutilstestcase import BlivetUtilsTestCase, BlivetUtilsTestToolkit
+from .blivetutilstestcase import BlivetUtilsTestCase, BlivetUtilsTestToolkit
 
 
 class DisksTestToolkit(BlivetUtilsTestToolkit):

--- a/tests/blivetutils_tests/test_20_partitioning.py
+++ b/tests/blivetutils_tests/test_20_partitioning.py
@@ -8,9 +8,8 @@ from gi.repository import BlockDev
 
 from blivetgui.communication.proxy_utils import ProxyDataContainer
 
-from blivetutilstestcase import BlivetUtilsTestCase
-
-from test_10_disks import DisksTestToolkit
+from .blivetutilstestcase import BlivetUtilsTestCase
+from .test_10_disks import DisksTestToolkit
 
 
 SIZE_DELTA = blivet.size.Size("2 MiB")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+
+from __future__ import print_function
+
+import os
+import six
+import sys
+import argparse
+import unittest
+
+
+def _get_tests_from_suite(suite, tests):
+    """ Extract tests from the test suite """
+    # 'tests' we get from 'unittest.defaultTestLoader.discover' are "wrapped"
+    # in multiple 'unittest.suite.TestSuite' classes/lists so we need to "unpack"
+    # the indivudual test cases
+    for test in suite:
+        if isinstance(test, unittest.suite.TestSuite):
+            _get_tests_from_suite(test, tests)
+
+        if isinstance(test, unittest.TestCase):
+            tests.append(test)
+
+    return tests
+
+
+def parse_args():
+    argparser = argparse.ArgumentParser(description="Blivet-GUI test suite")
+    argparser.add_argument("testname", nargs="?",
+                           help="name of test class or method (e. g. 'blivetutils_tests.edit_dialog_test')")
+    argparser.add_argument("-i", "--installed", dest="installed",
+                           help="run tests against installed version of libblockdev",
+                           action="store_true")
+    return argparser.parse_args()
+
+
+def main():
+    testdir = os.path.abspath(os.path.dirname(__file__))
+    projdir = os.path.abspath(os.path.normpath(os.path.join(testdir, "..")))
+
+    suite = unittest.TestSuite()
+    args = parse_args()
+
+    if not args.installed and "PYTHONPATH" not in os.environ:
+        os.environ["PYTHONPATH"] = projdir  # pylint: disable=environment-modify
+
+        try:
+            pyver = "python3" if six.PY3 else "python"
+            os.execv(sys.executable, [pyver] + sys.argv)
+        except OSError as e:
+            print("Failed re-exec with a new PYTHONPATH: %s" % str(e))
+            sys.exit(1)
+
+    testdir = os.path.abspath(os.path.dirname(__file__))
+
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite()
+    test_cases = loader.discover(start_dir=testdir, pattern='*test*.py')
+
+    tests = []
+    tests = _get_tests_from_suite(test_cases, tests)
+
+    for test in tests:
+        if args.testname and not test.id().startswith(args.testname):
+            continue
+
+        suite.addTest(test)
+
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+
+    if result.wasSuccessful():
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This also allows running the test suite against the installed
version of blivet-gui, for example in the Fedora CI.