### PR TITLE
Update packit Copr targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,7 +3,6 @@ jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-29-x86_64
     - fedora-30-x86_64
     - fedora-31-x86_64
     - fedora-rawhide-x86_64


### PR DESCRIPTION
F29 is EOL and Copr chroots for it have been removed.