### PR TITLE
packit: Use 'fedora-all' as Copr build targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,9 +3,7 @@ jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
   trigger: pull_request
 specfile_path: blivet-gui.spec
 synced_files:


### PR DESCRIPTION
This should automatically build on all available versions of
Fedora.