### PR TITLE
Fix setting attributes for proxy objects (#1810855)

### DIFF
--- a/blivetgui/communication/client.py
+++ b/blivetgui/communication/client.py
@@ -38,6 +38,8 @@ from ..i18n import _
 
 class ClientProxyObject(object):
 
+    attrs = ("client", "proxy_id")
+
     def __init__(self, client, proxy_id):
         self.client = client
         self.proxy_id = proxy_id
@@ -88,6 +90,17 @@ class ClientProxyObject(object):
 
         else:
             return remote_attr
+
+    def __setattr__(self, attr_name, value):
+        if attr_name in self.attrs + tuple(object.__dict__.keys()):
+            super().__setattr__(attr_name, value)
+        else:
+            remote_res = self.client.remote_method(self.proxy_id, "__setattr__", (attr_name, value), {})
+
+            if isinstance(remote_res, BaseException):
+                raise remote_res
+            else:
+                return remote_res
 
 
 class BlivetGUIClient(object):

--- a/blivetgui/communication/server.py
+++ b/blivetgui/communication/server.py
@@ -48,6 +48,8 @@ class BlivetProxyObject(object):
     """ Class representing unpicklable objects
     """
 
+    attrs = ("blivet_object", "id")
+
     def __init__(self, blivet_object, obj_id):
         self.blivet_object = blivet_object
         self.id = obj_id
@@ -59,6 +61,12 @@ class BlivetProxyObject(object):
         subobject = getattr(self.blivet_object, name)
 
         return subobject
+
+    def __setattr__(self, name, value):
+        if name in self.attrs + tuple(object.__dict__.keys()):
+            super().__setattr__(name, value)
+        else:
+            return setattr(self.blivet_object, name, value)
 
     def is_method(self, param_name):
         subobject = getattr(self.blivet_object, param_name)

--- a/tests/blivetgui_tests/server_test.py
+++ b/tests/blivetgui_tests/server_test.py
@@ -117,7 +117,7 @@ class BlivetProxyObjectTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.blivet_object = MagicMock()
+        cls.blivet_object = MagicMock(set_test=None)
         del cls.blivet_object.non_existing  # mock non-existing attribude
         cls.obj_id = ProxyID()
         cls.proxy_object = BlivetProxyObject(cls.blivet_object, cls.obj_id)
@@ -126,6 +126,10 @@ class BlivetProxyObjectTest(unittest.TestCase):
         self.assertEqual(self.proxy_object.existing, self.blivet_object.existing)
         with self.assertRaises(AttributeError):
             self.proxy_object.non_existing  # pylint: disable=W0104
+
+    def test_setattr(self):
+        self.proxy_object.set_test = "test"
+        self.assertEqual(self.blivet_object.set_test, "test")
 
     def test_getitem(self):
         self.assertEqual(self.proxy_object["key"], self.blivet_object["key"])  # pylint: disable=unsubscriptable-object


### PR DESCRIPTION
This fixes bug with setting mountpoint in the installer mode.
Setting attributes used to work with older versions of Python
without overriding the "__setattr__" method on proxy objects.