### PR TITLE
Fix unlocking LUKS on RAID in the installer mode (#1787508)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -173,6 +173,8 @@ class BlivetUtils(object):
     """ Class with utils directly working with blivet itselves
     """
 
+    installer_mode = False
+
     def __init__(self, ignored_disks=None, exclusive_disks=None):
 
         self.ignored_disks = ignored_disks
@@ -1385,6 +1387,8 @@ class BlivetUtils(object):
         blivet_device.format.passphrase = passphrase
 
         try:
+            if self.installer_mode:
+                blivet_device.setup()
             blivet_device.format.setup()
 
         except blivet.errors.LUKSError:

--- a/blivetgui/osinstall.py
+++ b/blivetgui/osinstall.py
@@ -51,6 +51,8 @@ from contextlib import contextmanager
 
 class BlivetUtilsAnaconda(BlivetUtils):
 
+    installer_mode = True
+
     def __init__(self):
         # pylint: disable=super-init-not-called
 


### PR DESCRIPTION
When running in Anaconda composite devices like RAIDs are teared
down so we need to run setup() on the device before trying to
unlockit it.