### PR TITLE
Do not update filesystem info for resize in the installer mode

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -652,16 +652,17 @@ class BlivetUtils(object):
             return ProxyDataContainer(resizable=False, error=msg, min_size=blivet.size.Size("1 MiB"),
                                       max_size=blivet_device.size)
 
-        try:
-            blivet_device.format.update_size_info()
+        if not self.installer_mode:
+            try:
+                blivet_device.format.update_size_info()
 
-            if blivet_device.type == "luks/dm-crypt":
-                blivet_device.slave.format.update_size_info()
+                if blivet_device.type == "luks/dm-crypt":
+                    blivet_device.slave.format.update_size_info()
 
-        except blivet.errors.FSError as e:
-            return ProxyDataContainer(resizable=False, error=str(e),
-                                      min_size=blivet.size.Size("1 MiB"),
-                                      max_size=blivet_device.size)
+            except blivet.errors.FSError as e:
+                return ProxyDataContainer(resizable=False, error=str(e),
+                                          min_size=blivet.size.Size("1 MiB"),
+                                          max_size=blivet_device.size)
 
         if blivet_device.resizable and blivet_device.format.resizable:
 


### PR DESCRIPTION
Blivet runs update_size_info automatically in Anaconda so we don't
need to do it again. Also our update_size_info call will always
fail for LVs because they are no longer active when blivet-gui is
running (because anaconda runs teardown_all during populate).

Resolves: rhbz#1826370