### PR TITLE
Ellipse the device name using the GTK cell render

### DIFF
--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -133,7 +133,6 @@ class ListPartitions(object):
         """
 
         devtype = "lvm" if device.type == "lvmvg" else "raid" if device.type == "mdarray" else device.type
-        name = device.name if len(device.name) < 18 else device.name[:15] + "..."  # FIXME
         fmt = device.format.type if device.format else None
         if self.installer_mode:
             mnt = device.format.mountpoint if (device.format and device.format.mountable) else None
@@ -150,7 +149,7 @@ class ListPartitions(object):
         else:
             label = ""
 
-        device_iter = self.partitions_list.append(parent_iter, [device, name, devtype, fmt, str(device.size), label, mnt])
+        device_iter = self.partitions_list.append(parent_iter, [device, device.name, devtype, fmt, str(device.size), label, mnt])
 
         return device_iter
 

--- a/data/ui/blivet-gui.ui
+++ b/data/ui/blivet-gui.ui
@@ -463,9 +463,12 @@
                             <child>
                               <object class="GtkTreeViewColumn" id="column_device">
                                 <property name="resizable">True</property>
+                                <property name="fixed_width">110</property>
                                 <property name="title" translatable="yes">Device</property>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext_device"/>
+                                  <object class="GtkCellRendererText" id="cellrenderertext_device">
+                                    <property name="ellipsize">end</property>
+                                  </object>
                                   <attributes>
                                     <attribute name="text">1</attribute>
                                   </attributes>

--- a/tests/blivetgui_tests/list_partitions_test.py
+++ b/tests/blivetgui_tests/list_partitions_test.py
@@ -107,7 +107,7 @@ class ListPartitionsTest(unittest.TestCase):
         device.configure_mock(name="".join(["a" for i in range(20)]))
 
         it = self.list_partitions._add_to_store(device)
-        self.assertEqual(self.list_partitions.partitions_list.get_value(it, 1), device.name[:15] + "...")
+        self.assertEqual(self.list_partitions.partitions_list.get_value(it, 1), device.name)
         self.assertEqual(self.list_partitions.partitions_list.get_value(it, 2), "lvm")
         self.assertIsNone(self.list_partitions.partitions_list.get_value(it, 3))
         self.assertEqual(self.list_partitions.partitions_list.get_value(it, 4), str(device.size))


### PR DESCRIPTION
The fedora install defaults the volume group to be named "fedora_hostname" and because the device list prefixes the logical volumes with this I was unable to see the names of most of my logical volumnes as they were truncated after 15 characters and wouldn't display even if I resized the column. 

I switched from the hard coded truncation to letting the GTK cell render truncate based on the column width as it allows the user to see longer names if they resize the column.

The "fixed width" of 110 comes from looking at the old UI and how wide the column was with the existing 18 character max length (15 + three ellipses)