### PR TITLE
Refactor checking for device resizability

### DIFF
--- a/blivetgui/dialogs/edit_dialog.py
+++ b/blivetgui/dialogs/edit_dialog.py
@@ -66,6 +66,7 @@ class ResizeDialog(object):
             self.size_chooser = self._add_size_chooser()
         else:
             self._add_resize_info()
+            button_resize.hide()
 
     def set_decorated(self, decorated):
         self.dialog.set_decorated(decorated)

--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -175,14 +175,13 @@ class ListPartitions(object):
                     return not device.format.status
 
     def _allow_resize_device(self, device):
-        if device.protected or device.children:
+        if device.protected or device.children or device.format_immutable:
             return False
 
-        if device.type not in ("partition", "lvmlv", "luks/dm-crypt"):
+        if not device._resizable:
             return False
 
-        return device.resizable and device.format.resizable \
-            and (device.max_size > device.size or device.min_size < device.size)
+        return True
 
     def _allow_format_device(self, device):
         if device.protected or device.children:


### PR DESCRIPTION
We currently decide if the device is resizable completely in the
GUI using the "_allow_resize_device" function which makes some of
the devices not resizable even if they can be resized. To properly
decide we usually need to call "update_size_info" on the format
first.
This change moves the decision to the backend (except for devices
that clearly can't be resized, like protected or unsupported
devices) and shows the reason for the device not being resizable
in the resize dialog.

Fixes: #175 