### PR TITLE
Fix unlocking raw format LUKS devices in Anaconda (#1846517)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -94,6 +94,9 @@ class RawFormatDevice(object):
     def protected(self):
         return self.disk.protected
 
+    def setup(self):
+        return self.disk.setup()
+
 
 class FreeSpaceDevice(object):
     """ Special class to represent free space on disk (device)


### PR DESCRIPTION
We now call setup() on encrypted devices prior to trying to unlock
them in the installer mode to fix issues with devices stopped or
deactivated during the installation environment setup, see
56d97b3b7dead7a80fc9d50bcd373e8390843cd8 but this doesn't work for
devices represented by the RawFormatDevice class in blivet-gui so
we need to propage the setup() call to the underlying disk.

----

I really need to remove the `RawFormatDevice` "device". It orignally looked like a great way to visualize raw format disks, but it only causes more and more issues right now.