### PR TITLE
Remove dependency on adwaita-icon-theme

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -31,7 +31,6 @@ Requires: gtk3
 Requires: PolicyKit-authentication-agent
 Requires: python3-pid
 Requires: libreport
-Requires: adwaita-icon-theme
 
 %description -n blivet-gui-runtime
 This package provides a blivet-gui runtime for applications that want to use


### PR DESCRIPTION
It's not really needed, any theme with the "symbolic" icons will
do and since dba6d24962428992dacf3430225e206dc6eb4cf1 blivet-gui
will no longer crash when trying to load non-existing icons.