### PR TITLE
Pip friendly installation

### DIFF
--- a/blivetgui/gui_utils.py
+++ b/blivetgui/gui_utils.py
@@ -41,7 +41,9 @@ def locate_ui_file(filename):
     """
 
     path = [os.path.split(os.path.abspath(__file__))[0] + '/../data/ui/',
-            '/usr/share/blivet-gui/ui/']
+            '/usr/share/blivet-gui/ui/',
+            '/usr/local/share/blivet-gui/ui/',
+            os.path.expanduser('~/.local/share/blivet-gui/ui/')]
 
     for folder in path:
         filepath = folder + filename
@@ -56,7 +58,9 @@ def locate_css_file(filename):
     """
 
     path = [os.path.split(os.path.abspath(__file__))[0] + '/../data/css/',
-            '/usr/share/blivet-gui/css/']
+            '/usr/share/blivet-gui/css/',
+            '/usr/local/share/blivet-gui/css/',
+            os.path.expanduser('~/.local/share/blivet-gui/css/')]
 
     for folder in path:
         filepath = folder + filename

--- a/setup.py
+++ b/setup.py
@@ -15,18 +15,18 @@ desktop_files = glob.glob('blivet-gui.desktop')
 man_files = glob.glob('man/blivet-gui.1')
 appdata_files = glob.glob('appdata/*.xml')
 
-data_files.append(('/usr/share/blivet-gui/ui', ui_files))
-data_files.append(('/usr/share/blivet-gui/css', css_files))
-data_files.append(('/usr/share/blivet-gui/img', img_files))
-data_files.append(('/usr/share/polkit-1/actions', polkit_files))
+data_files.append(('share/blivet-gui/ui', ui_files))
+data_files.append(('share/blivet-gui/css', css_files))
+data_files.append(('share/blivet-gui/img', img_files))
+data_files.append(('share/polkit-1/actions', polkit_files))
 data_files.append(('/etc/libreport/events.d', libreport_files))
-data_files.append(('/usr/share/applications', desktop_files))
-data_files.append(('/usr/share/man/man1', man_files))
-data_files.append(('/usr/share/appdata', appdata_files))
+data_files.append(('share/applications', desktop_files))
+data_files.append(('share/man/man1', man_files))
+data_files.append(('share/appdata', appdata_files))
 
 for size in ("16x16", "22x22", "24x24", "32x32", "48x48", "64x64", "256x256"):
     icons = glob.glob('data/icons/hicolor/' + size + '/blivet-gui.png')
-    data_files.append(('/usr/share/icons/hicolor/' + size + '/apps', icons))
+    data_files.append(('share/icons/hicolor/' + size + '/apps', icons))
 
 # Extend the sdist command
 class blivet_gui_sdist(sdist):


### PR DESCRIPTION
Installation from repositories (where possible) is still preferred, but this should make manual installation using pip a little bit more user-friendly.