### PR TITLE
Gather resizable filesystems from blivet instead of hardcoding

### DIFF
--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -157,8 +157,7 @@ class BlivetGUI(object):
         if self._supported_filesystems:
             return self._supported_filesystems
 
-        self._supported_filesystems = self.client.remote_call("get_supported_filesystems",
-                                                              self.installer_mode)
+        self._supported_filesystems = self.client.remote_call("get_supported_filesystems")
         return self._supported_filesystems
 
     def initialize(self):


### PR DESCRIPTION
Blivet uses the "_resizable" parameter for both indicating that
the filesystem is not resizable and that we don't have enough
information to tell (e.g. running "update_size_info" is needed
firsts) so we need to gather the information from the class object
instead from the filesystem instance.