### PR TITLE
Do not force "safe" names for devices (#1859963)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -834,8 +834,6 @@ class BlivetUtils(object):
                 name = self.storage.suggest_container_name()
 
         else:
-            name = self.storage.safe_device_name(name)
-
             # if name exists add -XX suffix
             if name in self.storage.names or (parent_device and parent_device.name + "-" + name in self.storage.names):
                 for i in range(100):


### PR DESCRIPTION
We validate names in GUI so there is no need to replace the name
with a "safe" one.