### PR TITLE
Unify/fix terminology for (un)locking encrypted devices

### DIFF
--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -686,7 +686,7 @@ class BlivetGUI(object):
         self.update_partitions_view()
 
     def decrypt_device(self, _widget=None):
-        """ Decrypt selected device
+        """ Unlock selected device
 
             :param widget: widget calling this function (only for calls via signal.connect)
             :type widget: Gtk.Widget()
@@ -700,7 +700,7 @@ class BlivetGUI(object):
             ret = self.client.remote_call("luks_decrypt", self.list_partitions.selected_partition[0], response)
 
             if not ret:
-                msg = _("Device decryption failed. Are you sure provided password is correct?")
+                msg = _("Unlocking failed. Are you sure provided password is correct?")
                 self.show_error_dialog(msg)
                 return
 

--- a/blivetgui/visualization/rectangle.py
+++ b/blivetgui/visualization/rectangle.py
@@ -49,8 +49,8 @@ class Rectangle(Gtk.RadioButton):
 
         self.device_icons = {"group": ("drive-multidisk-symbolic", _("Group device")),
                              "livecd": ("media-optical-symbolic", _("LiveUSB device")),
-                             "encrypted": ("changes-prevent-symbolic", _("Encrypted device (closed)")),
-                             "decrypted": ("changes-allow-symbolic", _("Encrypted device (open)")),
+                             "encrypted": ("changes-prevent-symbolic", _("Encrypted device (locked)")),
+                             "decrypted": ("changes-allow-symbolic", _("Encrypted device (unlocked)")),
                              "empty": ("radio-symbolic", _("Empty device")),
                              "snapshot": ("camera-photo-symbolic", _("Snapshot")),
                              "nodisklabel": ("drive-harddisk-symbolic", _("Missing partition table")),

--- a/data/ui/luks_passphrase_dialog.ui
+++ b/data/ui/luks_passphrase_dialog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkMessageDialog" id="dialog">
@@ -8,9 +8,9 @@
     <property name="type_hint">dialog</property>
     <property name="message_type">other</property>
     <property name="buttons">ok-cancel</property>
-    <property name="text" translatable="yes">Decrypt device</property>
-    <property name="secondary_text" translatable="yes">Please enter passphrase to decrypt selected device.</property>
-    <child>
+    <property name="text" translatable="yes">Unlock device</property>
+    <property name="secondary_text" translatable="yes">Please enter passphrase to unlock selected device.</property>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child internal-child="vbox">


### PR DESCRIPTION
"Decrypt" is completely wrong here and open/close can be confusing
so lets use "lock" and "unlock" in user-visible strings.