### PR TITLE
Hardcode list of supported filesystems for AddDialog tests

### DIFF
--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -15,16 +15,11 @@ from blivet import formats
 def supported_filesystems():
     _fs_types = []
 
-    additional_fs = ["swap", "lvmpv"]
+    _supported_fs = ["ext2", "ext3", "ext4", "xfs", "swap", "lvmpv"]
 
     for cls in formats.device_formats.values():
         obj = cls()
-
-        supported_fs = (obj.type not in ("tmpfs",) and
-                        obj.supported and obj.formattable and
-                        (isinstance(obj, formats.fs.FS) or
-                         obj.type in additional_fs))
-        if supported_fs:
+        if obj.type in _supported_fs:
             _fs_types.append(obj)
 
     return sorted(_fs_types, key=lambda fs: fs.type)


### PR DESCRIPTION
For this test we don't really need to check for system support of
the filesystem, we just need a "stable" list of filesystems to
check. Also some of the formats (like LVMPV) are not "supported"
when running as a non-root user.