### PR TITLE
Handle sector mode NVDIMMs as disks

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -115,13 +115,13 @@ class FreeSpaceDevice(object):
 
     @property
     def is_empty_disk(self):
-        return len(self.parents) == 1 and self.parents[0].type == "disk" and \
+        return len(self.parents) == 1 and self.parents[0].type in ("disk", "nvdimm") and \
             not self.parents[0].children and self.parents[0].format.type and \
             self.parents[0].format.type not in ("iso9660",)
 
     @property
     def is_uninitialized_disk(self):
-        return len(self.parents) == 1 and self.parents[0].type == "disk" and \
+        return len(self.parents) == 1 and self.parents[0].type in ("disk", "nvdimm") and \
             not self.parents[0].children and not self.parents[0].format.type
 
     @property


### PR DESCRIPTION
This is not ideal, but we can't use the "is_disk" property from
blivet because it is True also for RAID arrays.