### PR TITLE
spec: Require all libblockdev plugins

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -12,6 +12,7 @@ BuildRequires: libappstream-glib
 
 Requires: blivet-gui-runtime = %{version}-%{release}
 Requires: PolicyKit-authentication-agent
+Requires: libblockdev-plugins-all
 
 %description
 Graphical (GTK) tool for manipulation and configuration of data storage


### PR DESCRIPTION
We should be in theory able to run without some specific plugins
but it can be confusing especially with recent changes to installer
and blivet dependencies and it's easier to just require all
plugins in the blivet-gui package.