### PR TITLE
Add make to build dependencies

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -24,6 +24,7 @@ Summary: blivet-gui runtime
 BuildRequires: python3-devel
 BuildRequires: gettext >= 0.18.3
 BuildRequires: python3-setuptools
+BuildRequires: make
 
 Requires: python3
 Requires: python3-gobject


### PR DESCRIPTION
make is no longer part of the default build environment in Fedora.