### PR TITLE
Do not allow setting chunk size for RAID 1 (#1996223)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -1209,12 +1209,16 @@ class BlivetUtils(object):
             actions.extend(part_actions)
 
         md_parents = [ac.device for ac in actions if ac.is_format and ac._format.type == "mdmember"]
+        if user_input.advanced:
+            chunk_size = user_input.advanced["chunk_size"]
+        else:
+            chunk_size = None
         new_md = MDRaidArrayDevice(parents=md_parents,
                                    name=device_name,
                                    level=user_input.raid_level,
                                    member_devices=len(md_parents),
                                    total_devices=len(md_parents),
-                                   chunk_size=user_input.advanced["chunk_size"])
+                                   chunk_size=chunk_size)
         actions.append(blivet.deviceaction.ActionCreateDevice(new_md))
 
         if user_input.encrypt:

--- a/blivetgui/communication/proxy_utils.py
+++ b/blivetgui/communication/proxy_utils.py
@@ -59,7 +59,7 @@ class ProxyID(object):
     _newid_gen = functools.partial(next, itertools.count())
 
     def __init__(self):
-        self.id = self._newid_gen()
+        self.id = self._newid_gen()  # pylint: disable=assignment-from-no-return
 
     def __repr__(self):
         return "'Proxy ID, %s'" % self.id

--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -489,6 +489,10 @@ class AddDialog(Gtk.Dialog):
     def on_raid_type_changed(self, _widget):
         self.add_size_area()
 
+        if self.selected_type == "mdraid":
+            self.add_advanced_options()
+            self.show_widgets(["advanced"])
+
     def select_selected_free_region(self):
         """ In parent list select the free region user selected checkbox as checked
         """
@@ -859,10 +863,15 @@ class AddDialog(Gtk.Dialog):
             self.advanced.destroy()
 
         if device_type in ("lvm", "lvmvg", "partition", "mdraid"):
-            self.advanced = AdvancedOptions(self, device_type, self.selected_parent, self.selected_free)
-            self.widgets_dict["advanced"] = [self.advanced]
+            if device_type == "mdraid" and self._raid_chooser.selected_level.name == "raid1":
+                self.advanced = None
+                self.widgets_dict["advanced"] = []
+            else:
+                self.advanced = AdvancedOptions(self, device_type, self.selected_parent,
+                                                self.selected_free)
+                self.widgets_dict["advanced"] = [self.advanced]
 
-            self.grid.attach(self.advanced.expander, 0, 15, 6, 1)
+                self.grid.attach(self.advanced.expander, 0, 15, 6, 1)
 
         else:
             self.advanced = None

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -10,6 +10,7 @@ import os
 
 from blivet.size import Size
 from blivet import formats
+from blivet.devicelibs import raid
 
 
 def supported_filesystems():
@@ -582,6 +583,17 @@ class AddDialogTest(unittest.TestCase):
 
         # raid0 type is selected --> we should have 2 size areas, both with max size 4 GiB (smaller free space size)
         self.assertEqual(add_dialog.size_area.max_size, Size("8 GiB"))
+
+        # raid0 is selected --> advanced options (chunk size) should be visible
+        self.assertIsNotNone(add_dialog.advanced)
+
+        # select raid1 --> advanced options (chunk size) should be disappear
+        add_dialog._raid_chooser.selected_level = raid.RAID1
+        self.assertIsNone(add_dialog.advanced)
+
+        # back to raid0 just to be sure
+        add_dialog._raid_chooser.selected_level = raid.RAID0
+        self.assertIsNotNone(add_dialog.advanced)
 
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_mountpoint_validity_check(self):


### PR DESCRIPTION
Similar change to https://github.com/storaged-project/blivet/pull/969 This makes sure the "advanced options" tab which allows setting chunk size for MD RAID is hidden and we don't set the default value when creating `MDRaidArrayDevice`.