### PR TITLE
Use setuptools instead of distutils in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
-from distutils.core import setup
-from distutils.command.sdist import sdist
+from setuptools import setup
+from setuptools.command.sdist import sdist
 import glob
 import sys
 


### PR DESCRIPTION
The distutils module is deprecated and will be removed in Python
3.12.