### PR TITLE
ui: Add Gtk.ScrolledWindow as parent for the logical Gtk.TreeView

### DIFF
--- a/data/ui/blivet-gui.ui
+++ b/data/ui/blivet-gui.ui
@@ -1,86 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAccelGroup" id="accelgroup"/>
   <object class="GtkMenu" id="actions_menu">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="accel_group">accelgroup</property>
+    <property name="can-focus">False</property>
+    <property name="accel-group">accelgroup</property>
     <child>
       <object class="GtkMenuItem" id="menuitem_add">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">New</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
         <accelerator key="Insert" signal="activate"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menuitem_delete">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Delete</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
         <accelerator key="Delete" signal="activate"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menuitem_edit">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Edit</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
         <child type="submenu">
           <object class="GtkMenu" id="submenu_edit">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkMenuItem" id="menuitem_resize">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Resize</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="menuitem_format">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes" context="Menu|Edit" comments="Edit format (e.g. delete existing and create a new one) on selected device.">Format</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="menuitem_parents">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Modify parents</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="menuitem_mountpoint">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Set mountpoint</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="menuitem_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Set label</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="menuitem_partitiontable">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Set partition table</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
             </child>
           </object>
@@ -90,119 +90,119 @@
     <child>
       <object class="GtkMenuItem" id="menuitem_unmount">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Unmount</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menuitem_decrypt">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Decrypt</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menuitem_info">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Information</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
   </object>
   <object class="GtkMenu" id="edit_button_menu">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkMenuItem" id="button_resize">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Resize</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="button_format">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes" context="Menu|Edit" comments="Edit format (e.g. delete existing and create a new one) on selected device.">Format</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="button_parents">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Modify parents</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="button_mountpoint">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Set mountpoint</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="button_label">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Set label</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="button_partitiontable">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Set partition table</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
   </object>
   <object class="GtkImage" id="image_add">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">list-add-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">list-add-symbolic</property>
   </object>
   <object class="GtkImage" id="image_apply">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">object-select-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">object-select-symbolic</property>
   </object>
   <object class="GtkImage" id="image_back">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">edit-undo-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-undo-symbolic</property>
   </object>
   <object class="GtkImage" id="image_clear">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">edit-clear-all-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-clear-all-symbolic</property>
   </object>
   <object class="GtkImage" id="image_decrypt">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">dialog-password-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-password-symbolic</property>
   </object>
   <object class="GtkImage" id="image_delete">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">edit-delete-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-delete-symbolic</property>
   </object>
   <object class="GtkImage" id="image_info">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">dialog-information-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-information-symbolic</property>
   </object>
   <object class="GtkImage" id="image_unmount">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">media-eject-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">media-eject-symbolic</property>
   </object>
   <object class="GtkListStore" id="liststore_devices">
     <columns>
@@ -233,11 +233,11 @@
     </columns>
   </object>
   <object class="GtkWindow" id="main_window">
-    <property name="width_request">800</property>
-    <property name="height_request">600</property>
-    <property name="can_focus">False</property>
+    <property name="width-request">800</property>
+    <property name="height-request">600</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">blivet-gui</property>
-    <property name="window_position">center</property>
+    <property name="window-position">center</property>
     <property name="gravity">static</property>
     <accel-groups>
       <group name="accelgroup"/>
@@ -246,26 +246,26 @@
     <child>
       <object class="GtkBox" id="vbox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkPaned" id="paned">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="vexpand">True</property>
             <property name="position">220</property>
             <child>
               <object class="GtkScrolledWindow" id="disks_window">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <child>
                   <object class="GtkTreeView" id="treeview_devices">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="model">liststore_devices</property>
-                    <property name="headers_visible">False</property>
-                    <property name="enable_search">False</property>
-                    <property name="show_expanders">False</property>
+                    <property name="headers-visible">False</property>
+                    <property name="enable-search">False</property>
+                    <property name="show-expanders">False</property>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection" id="treeview-selection3"/>
                     </child>
@@ -305,25 +305,25 @@
             <child>
               <object class="GtkBox" id="vbox_right">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkNotebook" id="notebook_views">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="show_border">False</property>
+                    <property name="can-focus">True</property>
+                    <property name="show-border">False</property>
                     <child>
                       <object class="GtkBox" id="box_logical">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkScrolledWindow" id="image_window">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="border_width">1</property>
-                            <property name="min_content_height">100</property>
-                            <property name="overlay_scrolling">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="border-width">1</property>
+                            <property name="min-content-height">100</property>
+                            <property name="overlay-scrolling">False</property>
                             <child>
                               <placeholder/>
                             </child>
@@ -338,14 +338,14 @@
                           <object class="GtkBox" id="box_toolbar">
                             <property name="name">bg-toolbar</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkButton" id="button_add">
                                 <property name="name">bg-toolbar-button-first</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes" context="ActionsToolbar|Add">Add new device</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes" context="ActionsToolbar|Add">Add new device</property>
                                 <property name="image">image_add</property>
                                 <accelerator key="Insert" signal="clicked"/>
                               </object>
@@ -359,9 +359,9 @@
                               <object class="GtkButton" id="button_delete">
                                 <property name="name">bg-toolbar-button-inner</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes" context="ActionsToolbar|Delete">Delete selected device</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes" context="ActionsToolbar|Delete">Delete selected device</property>
                                 <property name="image">image_delete</property>
                                 <accelerator key="Delete" signal="clicked"/>
                               </object>
@@ -375,19 +375,19 @@
                               <object class="GtkMenuButton" id="button_edit">
                                 <property name="name">bg-toolbar-button-inner</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes" context="ActionsToolbar|Edit">Edit selected device</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes" context="ActionsToolbar|Edit">Edit selected device</property>
                                 <property name="halign">center</property>
                                 <property name="valign">center</property>
                                 <property name="popup">edit_button_menu</property>
                                 <child>
                                   <object class="GtkImage" id="image_edit">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_top">2</property>
-                                    <property name="margin_bottom">3</property>
-                                    <property name="icon_name">system-run-symbolic</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">2</property>
+                                    <property name="margin-bottom">3</property>
+                                    <property name="icon-name">system-run-symbolic</property>
                                   </object>
                                 </child>
                               </object>
@@ -401,9 +401,9 @@
                               <object class="GtkButton" id="button_unmount">
                                 <property name="name">bg-toolbar-button-inner</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes" context="ActionsToolbar|Unmount">Unmount selected device</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes" context="ActionsToolbar|Unmount">Unmount selected device</property>
                                 <property name="image">image_unmount</property>
                               </object>
                               <packing>
@@ -416,9 +416,9 @@
                               <object class="GtkButton" id="button_decrypt">
                                 <property name="name">bg-toolbar-button-inner</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes" context="ActionsToolbar|Decrypt">Unlock/Open selected device</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes" context="ActionsToolbar|Decrypt">Unlock/Open selected device</property>
                                 <property name="image">image_decrypt</property>
                               </object>
                               <packing>
@@ -431,9 +431,9 @@
                               <object class="GtkButton" id="button_info">
                                 <property name="name">bg-toolbar-button-last</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes" context="ActionsToolbar|Info">Display information about selected device</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes" context="ActionsToolbar|Info">Display information about selected device</property>
                                 <property name="image">image_info</property>
                               </object>
                               <packing>
@@ -450,81 +450,87 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkTreeView" id="treeview_logical">
+                          <object class="GtkScrolledWindow" id="scrolledwindow_physica">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="model">liststore_logical</property>
-                            <child internal-child="selection">
-                              <object class="GtkTreeSelection" id="treeview-selection2"/>
-                            </child>
+                            <property name="can-focus">True</property>
+                            <property name="shadow-type">in</property>
                             <child>
-                              <object class="GtkTreeViewColumn" id="column_device">
-                                <property name="resizable">True</property>
-                                <property name="fixed_width">110</property>
-                                <property name="title" translatable="yes">Device</property>
+                              <object class="GtkTreeView" id="treeview_logical">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="model">liststore_logical</property>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext_device">
-                                    <property name="ellipsize">end</property>
+                                  <object class="GtkTreeViewColumn" id="column_device">
+                                    <property name="resizable">True</property>
+                                    <property name="fixed-width">110</property>
+                                    <property name="title" translatable="yes">Device</property>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext_device">
+                                        <property name="ellipsize">end</property>
+                                      </object>
+                                      <attributes>
+                                        <attribute name="text">1</attribute>
+                                      </attributes>
+                                    </child>
                                   </object>
-                                  <attributes>
-                                    <attribute name="text">1</attribute>
-                                  </attributes>
                                 </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkTreeViewColumn" id="column_name">
-                                <property name="title" translatable="yes">Type</property>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext_type"/>
-                                  <attributes>
-                                    <attribute name="text">2</attribute>
-                                  </attributes>
+                                  <object class="GtkTreeViewColumn" id="column_name">
+                                    <property name="title" translatable="yes">Type</property>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext_type"/>
+                                      <attributes>
+                                        <attribute name="text">2</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
                                 </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkTreeViewColumn" id="column_format">
-                                <property name="title" translatable="yes" context="LogicalView|Column" comments="Format (filesystem) type of selected device.">Format</property>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext_format"/>
-                                  <attributes>
-                                    <attribute name="text">3</attribute>
-                                  </attributes>
+                                  <object class="GtkTreeViewColumn" id="column_format">
+                                    <property name="title" translatable="yes" context="LogicalView|Column" comments="Format (filesystem) type of selected device.">Format</property>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext_format"/>
+                                      <attributes>
+                                        <attribute name="text">3</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
                                 </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkTreeViewColumn" id="column_size">
-                                <property name="title" translatable="yes">Size</property>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext_size"/>
-                                  <attributes>
-                                    <attribute name="text">4</attribute>
-                                  </attributes>
+                                  <object class="GtkTreeViewColumn" id="column_size">
+                                    <property name="title" translatable="yes">Size</property>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext_size"/>
+                                      <attributes>
+                                        <attribute name="text">4</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
                                 </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkTreeViewColumn" id="column_label">
-                                <property name="title" translatable="yes">Label</property>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext_label"/>
-                                  <attributes>
-                                    <attribute name="text">5</attribute>
-                                  </attributes>
+                                  <object class="GtkTreeViewColumn" id="column_label">
+                                    <property name="title" translatable="yes">Label</property>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext_label"/>
+                                      <attributes>
+                                        <attribute name="text">5</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
                                 </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkTreeViewColumn" id="column_mountpoint">
-                                <property name="title" translatable="yes">Mountpoint</property>
                                 <child>
-                                  <object class="GtkCellRendererText" id="cellrenderertext_mountpoint"/>
-                                  <attributes>
-                                    <attribute name="text">6</attribute>
-                                  </attributes>
+                                  <object class="GtkTreeViewColumn" id="column_mountpoint">
+                                    <property name="title" translatable="yes">Mountpoint</property>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext_mountpoint"/>
+                                      <attributes>
+                                        <attribute name="text">6</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
                                 </child>
                               </object>
                             </child>
@@ -540,18 +546,18 @@
                     <child type="tab">
                       <object class="GtkLabel" id="label_logical">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Logical View</property>
                       </object>
                       <packing>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow_physical">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="border_width">6</property>
+                        <property name="can-focus">True</property>
+                        <property name="border-width">6</property>
                         <child>
                           <placeholder/>
                         </child>
@@ -563,19 +569,19 @@
                     <child type="tab">
                       <object class="GtkLabel" id="label_physical">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Physical View</property>
                       </object>
                       <packing>
                         <property name="position">1</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="pack_type">end</property>
+                    <property name="pack-type">end</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -599,15 +605,15 @@
           <object class="GtkButton" id="button_actions">
             <property name="name">bg-button-actions</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="focus_on_click">False</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="focus-on-click">False</property>
+            <property name="receives-default">True</property>
             <property name="halign">start</property>
             <property name="relief">none</property>
             <child>
               <object class="GtkLabel" id="label_actions">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">No pending actions</property>
               </object>
             </child>
@@ -620,9 +626,6 @@
         </child>
       </object>
     </child>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkTreeStore" id="liststore_physical">
     <columns>
@@ -634,65 +637,65 @@
   </object>
   <object class="GtkMenu" id="main_menu">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="halign">end</property>
     <child>
       <object class="GtkMenuItem" id="menuitem_reload">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Reload Storage</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menuitem_actions">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Queued Actions</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menuitem_quit">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Quit</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkSeparatorMenuItem" id="menuitem_sep1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menuitem_about">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">About blivet-gui</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
   </object>
   <object class="GtkBox" id="vbox_topbar">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkFrame" id="frame_device">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label_xalign">0</property>
-        <property name="shadow_type">none</property>
+        <property name="can-focus">False</property>
+        <property name="label-xalign">0</property>
+        <property name="shadow-type">none</property>
         <child>
           <object class="GtkAlignment" id="aligment_device">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="left_padding">12</property>
+            <property name="can-focus">False</property>
+            <property name="left-padding">12</property>
             <child>
               <object class="GtkLabel" id="label_device">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
               </object>
             </child>
           </object>
@@ -700,7 +703,7 @@
         <child type="label">
           <object class="GtkLabel" id="label_frame">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="lines">1</property>
           </object>
         </child>
@@ -714,14 +717,14 @@
     <child>
       <object class="GtkBox" id="vbox_toolbar">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">6</property>
         <property name="homogeneous">True</property>
         <child>
           <object class="GtkButton" id="button_apply">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="image">image_apply</property>
@@ -735,8 +738,8 @@
         <child>
           <object class="GtkButton" id="button_clear">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="image">image_clear</property>
@@ -750,8 +753,8 @@
         <child>
           <object class="GtkButton" id="button_back">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="image">image_back</property>
@@ -765,20 +768,20 @@
         <child>
           <object class="GtkMenuButton" id="mainmenu_menubutton">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="double_buffered">False</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="double-buffered">False</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="popup">main_menu</property>
-            <property name="use_popover">False</property>
+            <property name="use-popover">False</property>
             <child>
               <object class="GtkImage" id="image_menu">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">2</property>
-                <property name="margin_bottom">3</property>
-                <property name="icon_name">open-menu-symbolic</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">2</property>
+                <property name="margin-bottom">3</property>
+                <property name="icon-name">open-menu-symbolic</property>
               </object>
             </child>
           </object>
@@ -793,7 +796,7 @@
         <property name="expand">False</property>
         <property name="fill">False</property>
         <property name="padding">6</property>
-        <property name="pack_type">end</property>
+        <property name="pack-type">end</property>
         <property name="position">1</property>
       </packing>
     </child>
@@ -810,9 +813,9 @@
   </object>
   <object class="GtkTreeView" id="treeview_actions">
     <property name="visible">True</property>
-    <property name="can_focus">True</property>
+    <property name="can-focus">True</property>
     <property name="model">treestore_actions</property>
-    <property name="headers_visible">False</property>
+    <property name="headers-visible">False</property>
     <child internal-child="selection">
       <object class="GtkTreeSelection" id="treeview-selection4"/>
     </child>


### PR DESCRIPTION
In some cases (especially when the device names or mountpoints are
too long) the logical view can "overflow" and cause the main menu
buttons to move "outside" the window. Adding a scrolled windows
prevents this.

Fixes: #311