### PR TITLE
Fix title for the label dialog

### DIFF
--- a/data/ui/label_dialog.ui
+++ b/data/ui/label_dialog.ui
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkDialog" id="label_dialog">
-    <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Format device</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Set filesystem label</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
     <property name="gravity">center</property>
-    <child>
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button_cancel">
                 <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
                 <property name="yalign">0.62000000476837158</property>
               </object>
               <packing>
@@ -38,8 +35,8 @@
               <object class="GtkButton" id="button_label">
                 <property name="label" translatable="yes" context="Dialog|Format" comments="Perform selected format change on this device.">Relabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -57,17 +54,17 @@
         <child>
           <object class="GtkBox" id="box">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_left">12</property>
-            <property name="margin_right">12</property>
-            <property name="margin_top">8</property>
-            <property name="margin_bottom">8</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">12</property>
+            <property name="margin-right">12</property>
+            <property name="margin-top">8</property>
+            <property name="margin-bottom">8</property>
             <property name="homogeneous">True</property>
             <child>
               <object class="GtkLabel" id="label_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_right">6</property>
+                <property name="can-focus">False</property>
+                <property name="margin-right">6</property>
                 <property name="label" translatable="yes">Enter new label for this filesystem:</property>
                 <property name="justify">center</property>
               </object>
@@ -80,7 +77,7 @@
             <child>
               <object class="GtkEntry" id="entry_label">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -97,15 +94,5 @@
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkListStore" id="liststore_format">
-    <columns>
-      <!-- column-name format -->
-      <column type="PyObject"/>
-      <!-- column-name type -->
-      <column type="gchararray"/>
-      <!-- column-name name -->
-      <column type="gchararray"/>
-    </columns>
   </object>
 </interface>


### PR DESCRIPTION
Copy-paste bug from the format dialog, the title originally said
"Format device" instead of "Set filesystem label".