### PR TITLE
spec: Add explicit dependency on polkit

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -12,6 +12,7 @@ BuildRequires: libappstream-glib
 
 Requires: blivet-gui-runtime = %{version}-%{release}
 Requires: PolicyKit-authentication-agent
+Requires: polkit
 Requires: libblockdev-plugins-all
 
 %description


### PR DESCRIPTION
polkit package provides "pkexec" which we use for starting the
privileged background process.