### PR TITLE
spec: Remove dependecy on gettext

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -29,7 +29,6 @@ BuildRequires: make
 
 Requires: python3
 Requires: python3-gobject
-Requires: gettext
 Requires: python3-blivet >= 1:3.3.0
 Requires: gtk3
 Requires: python3-pid


### PR DESCRIPTION
gettext is needed only during build time.