### PR TITLE
pylint: Remove deprecated pylint warnings from pylintrc and code

### DIFF
--- a/blivet-gui-daemon
+++ b/blivet-gui-daemon
@@ -36,7 +36,7 @@ from blivetgui.communication.server import BlivetUtilsServer
 # ---------------------------------------------------------------------------- #
 
 
-class BlivetGUIServer(socketserver.UnixStreamServer):  # pylint: disable=no-init
+class BlivetGUIServer(socketserver.UnixStreamServer):
     """ Custom UnixStreamServer instance
     """
 

--- a/blivetgui/communication/server.py
+++ b/blivetgui/communication/server.py
@@ -96,7 +96,7 @@ class BlivetProxyObject(object):
             return 1
 
 
-class BlivetUtilsServer(socketserver.BaseRequestHandler):  # pylint: disable=no-init
+class BlivetUtilsServer(socketserver.BaseRequestHandler):
     blivet_utils = None
     proxy_objects = []
     object_dict = {}

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -21,8 +21,7 @@ class BlivetGUILintConfig(PocketLintConfig):
 
     @property
     def disabledOptions(self):
-        return ["W0142",           # Used * or ** magic
-                "W0212",           # Access to a protected member of a client class
+        return ["W0212",           # Access to a protected member of a client class
                 "W0511",           # Used when a warning note as FIXME or XXX is detected.
                 "I0011",           # Locally disabling %s
                 ]


### PR DESCRIPTION
Latest pylint removed some deprecated warnings/messages and now
complains about disabling unknown messages.