### PR TITLE
Remove python3-mock from test dependencies

### DIFF
--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -28,7 +28,6 @@
   - name: Install test dependencies (Fedora)
     package: name={{item}} state=installed
     with_items:
-      - python3-mock
       - python3-coverage
       - python3-pocketlint
       - python3-pycodestyle
@@ -58,7 +57,6 @@
   - name: Install test dependencies (Ubuntu/Debian)
     package: name={{item}} state=present
     with_items:
-      - python3-mock
       - python3-coverage
       - python3-pycodestyle
       - pycodestyle


### PR DESCRIPTION
We using mock from unittest, no need for python3-mock.