### PR TITLE
Use "folder" icon for LVM and other "complex" devices

### DIFF
--- a/blivetgui/list_devices.py
+++ b/blivetgui/list_devices.py
@@ -96,7 +96,7 @@ class ListDevices(object):
         gdevices = self.blivet_gui.client.remote_call("get_group_devices")
 
         icon_theme = Gtk.IconTheme.get_default()  # pylint: disable=no-value-for-parameter
-        icon_group = Gtk.IconTheme.load_icon(icon_theme, "drive-multidisk", 32, 0)
+        icon_group = Gtk.IconTheme.load_icon(icon_theme, "folder", 32, 0)
 
         if gdevices["lvm"]:
             self.device_list.append([None, None, "<b>%s</b>" % _("LVM")])


### PR DESCRIPTION
We were using the "drive-multidisk" icon, but that's no longer
available in the default GNOME Adwaita theme (only as the symbolic
icon) so we need a new icon to make the look consistent. Folder
isn't the best, but there isn't a more fitting option.