### PR TITLE
Tell blivet to ignore zRAM devices

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -161,6 +161,9 @@ class BlivetUtils(object):
         blivet.formats.fs.NTFS._formattable = True
         blivet.formats.fs.NTFS._supported = True
 
+        # ignore zram devices
+        blivet.udev.ignored_device_names.append(r"^zram")
+
         self.blivet_reset()
         self._update_min_sizes_info()
 


### PR DESCRIPTION
zRAM devices are not scanned by udev so we see them as empty so
it's better to just not show them to not confuse users especially
because there is now a zRAM devices on every Fedora system used
for swap.