### PR TITLE
Allow creating biosboot even if not in installer mode

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -1425,12 +1425,10 @@ class BlivetUtils(object):
 
         return list(self.storage.mountpoints.keys())
 
-    def get_supported_filesystems(self, installer_mode=False):
+    def get_supported_filesystems(self):
         _fs_types = []
 
-        additional_fs = ["swap", "lvmpv"]
-        if installer_mode:
-            additional_fs.extend(["biosboot", "prepboot"])
+        additional_fs = ["swap", "lvmpv", "biosboot", "prepboot"]
 
         for cls in blivet.formats.device_formats.values():
             obj = cls()

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -164,8 +164,7 @@ class BlivetGUI(object):
         if self._supported_filesystems:
             return self._supported_filesystems
 
-        self._supported_filesystems = self.client.remote_call("get_supported_filesystems",
-                                                              self.installer_mode)
+        self._supported_filesystems = self.client.remote_call("get_supported_filesystems")
         return self._supported_filesystems
 
     def initialize(self):

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -538,7 +538,7 @@ class AddDialogTest(unittest.TestCase):
 
         add_dialog = AddDialog(self.parent_window, parent_device, free_device,
                                [("free", free_device)], _filesystems,
-                               [], True)  # with installer_mode=True
+                               [])
 
         # switch from biosboot to btrfs and ext4 (rhbz#1881472)
         add_dialog.filesystems_combo.set_active_id("biosboot")


### PR DESCRIPTION
With the new Anaconda WebUI more users are going to watn to create storage layout before starting the installation and we need to support creating biosboot in these cases.