### PR TITLE
pylint: Update pylintrc

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -372,11 +372,3 @@ int-import-graph=
 # Force import order to recognize a module as part of the standard
 # compatibility libraries.
 known-standard-library=
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception


### PR DESCRIPTION
Latest pylint changed how exceptions should be defined in pylintrc. We were using the defaults anyway so removing the section won't change anything and we don't need to deal with the new defaults.