### PR TITLE
pylint: Use 'exit' instead of 'do_exit' for pylint.lint.Run

### DIFF
--- a/tests/pylint/censorship.py
+++ b/tests/pylint/censorship.py
@@ -109,7 +109,7 @@ class CensorshipLinter():
 
         pylint.lint.Run(args,
                         reporter=TextReporter(self._stdout),
-                        do_exit=False)
+                        exit=False)
 
         return self._process_output()
 


### PR DESCRIPTION
The 'do_exit' keyword argument has been deprecated for a while and finally removed in pylinr 3.0.