### PR TITLE
spec: Bump release to 99 to be always ahead of the Fedora packages

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -1,7 +1,7 @@
 Summary: Tool for data storage configuration
 Name: blivet-gui
 Version: 2.4.2
-Release: 1%{?dist}
+Release: 99%{?dist}
 Source0: http://github.com/storaged-project/blivet-gui/releases/download/%{version}/%{name}-%{version}.tar.gz
 Source1: blivet-gui_event.conf
 License: GPL-2.0-or-later


### PR DESCRIPTION
The daily builds from Packit are now behind because the automatic rebuilds in Fedora have higher release.