### PR TITLE
ci: Set custom release suffix for Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,6 +18,10 @@ jobs:
   project: blivet-daily
   branch: main
   preserve_project: true
+  actions:
+    post-upstream-clone:
+      # bump release to 99 to always be ahead of Fedora builds
+      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release: 99%{?dist}/\" blivet-gui.spec"'
 
 - job: propose_downstream
   trigger: release

--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -1,7 +1,7 @@
 Summary: Tool for data storage configuration
 Name: blivet-gui
 Version: 2.4.2
-Release: 99%{?dist}
+Release: 1%{?dist}
 Source0: http://github.com/storaged-project/blivet-gui/releases/download/%{version}/%{name}-%{version}.tar.gz
 Source1: blivet-gui_event.conf
 License: GPL-2.0-or-later


### PR DESCRIPTION
We want a high release number (99) for the daily builds done by Packit to make sure the Copr daily builds are always newer than the version in Fedora. We can do this in Packit config instead of bumping the release in the spec everytime.