### PR TITLE
Guard better against RaidChooser's selected_level being None

### DIFF
--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -562,11 +562,12 @@ class AddDialog(Gtk.Dialog):
 
         device_type = self.selected_type
         num_parents = self._get_number_selected_parents()
+        level = self._raid_chooser.selected_level
 
         if device_type not in self.supported_raids.keys() or num_parents == 1:
             return (False, None)
 
-        elif self._raid_chooser.selected_level.name in ("linear", "single"):
+        elif level and level.name in ("linear", "single"):
             return (False, None)
 
         else:
@@ -863,7 +864,8 @@ class AddDialog(Gtk.Dialog):
             self.advanced.destroy()
 
         if device_type in ("lvm", "lvmvg", "partition", "mdraid"):
-            if device_type == "mdraid" and self._raid_chooser.selected_level.name == "raid1":
+            level = self._raid_chooser.selected_level
+            if device_type == "mdraid" and level and level.name == "raid1":
                 self.advanced = None
                 self.widgets_dict["advanced"] = []
             else:
@@ -1068,7 +1070,9 @@ class AddDialog(Gtk.Dialog):
         encryption_selection = self._encryption_chooser.get_selection()
 
         if device_type in ("btrfs volume", "mdraid", "lvmlv"):
-            raid_level = self._raid_chooser.selected_level.name
+            raid_level = self._raid_chooser.selected_level
+            if raid_level:
+                raid_level = raid_level.name
         else:
             raid_level = None
 


### PR DESCRIPTION
This happens more often since blivet dropped linear from mdraid in https://github.com/storaged-project/blivet/pull/1236 . It was the only RAID level supported for mdraid that had min_members of 1. When you add the first member for a new mdraid set, of course, there is only one member.

RaidChooser's update method checks the `min_members` on each level and only adds it to the liststore of available levels if we currently have at least that many members. So, before that blivet change, when there was only one member, "linear" was the only level in the liststore, and was necessarily the selected_level. Now linear is gone, when there is only one member of an mdraid set, there are *no* levels in the liststore, which means selected_level winds up being None.

There are three places I can see in add_dialog.py which don't guard against selected_level being None. This fixes each of them.