### PR TITLE
ci: Remove priority from Testing farm repositories

### DIFF
--- a/plans/tests.fmf
+++ b/plans/tests.fmf
@@ -6,6 +6,8 @@ prepare:
     script:
       - sudo dnf install -y 'dnf-command(copr)'
       - sudo dnf copr enable -y @storage/blivet-daily
+      - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done
+      - sudo dnf -y update
 
   - name: ansible
     how: ansible


### PR DESCRIPTION
Testing farm sets priority of their repositories to 9 which means the repo is prioritized over all other repositories including our Copr repo with daily builds preventing the latest blivet and libblockdev from being installed.