### PR TITLE
Fix displaying whole-disk MD arrays in installer mode

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -198,7 +198,7 @@ class BlivetUtils(object):
 
         """
 
-        return [device for device in self.storage.disks if device.type != "mdarray"]
+        return [device for device in self.storage.disks]
 
     def get_group_devices(self):
         """ Return list of LVM2 Volume Group devices

--- a/po/blivet-gui.pot
+++ b/po/blivet-gui.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-23 15:05+0100\n"
+"POT-Creation-Date: 2025-08-20 14:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -297,40 +297,44 @@ msgid_plural "%s pending actions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../blivetgui/list_devices.py:82
+#: ../blivetgui/list_devices.py:85
 msgid "Disks"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:102
+#: ../blivetgui/list_devices.py:92
+msgid "MDRAID set"
+msgstr ""
+
+#: ../blivetgui/list_devices.py:113
 msgid "LVM"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:105
+#: ../blivetgui/list_devices.py:116
 msgid "LVM2 VG"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:108
+#: ../blivetgui/list_devices.py:119
 msgid "RAID"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:111
+#: ../blivetgui/list_devices.py:122
 msgid "MDArray"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:114
+#: ../blivetgui/list_devices.py:125
 msgid "Btrfs Volumes"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:117 ../blivetgui/dialogs/add_dialog.py:389
+#: ../blivetgui/list_devices.py:128 ../blivetgui/dialogs/add_dialog.py:389
 #: ../blivetgui/dialogs/device_info_dialog.py:87
 msgid "Btrfs Volume"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:120
+#: ../blivetgui/list_devices.py:131
 msgid "Stratis Pools"
 msgstr ""
 
-#: ../blivetgui/list_devices.py:123 ../blivetgui/dialogs/add_dialog.py:392
+#: ../blivetgui/list_devices.py:134 ../blivetgui/dialogs/add_dialog.py:392
 msgid "Stratis Pool"
 msgstr ""
 


### PR DESCRIPTION
In Anaconda MD arrays created directly on top of disks are handled as disks so we should do the same.

Resolves: rhbz#2389105