### PR TITLE
Mark removing format optional when removing the device

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -575,7 +575,7 @@ class BlivetUtils(object):
 
         try:
             if not blivet_device.format_immutable:
-                ac_fmt = blivet.deviceaction.ActionDestroyFormat(blivet_device)
+                ac_fmt = blivet.deviceaction.ActionDestroyFormat(blivet_device, optional=True)
                 self.storage.devicetree.actions.add(ac_fmt)
                 actions.append(ac_fmt)
 


### PR DESCRIPTION
This is a new feature in blivet which prevents errors when removing devices that cannot be activated (like broken MD array or LVM LV).
See also https://github.com/storaged-project/blivet/pull/1383

Fixes: #448