### PR TITLE
Improve visualization for incomplete devices

### DIFF
--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -22,6 +22,9 @@
 #
 # ---------------------------------------------------------------------------- #
 
+import blivet
+from .i18n import _
+
 
 class ListPartitions(object):
     """ List of children of selected device
@@ -158,7 +161,14 @@ class ListPartitions(object):
         else:
             label = ""
 
-        device_iter = self.partitions_list.append(parent_iter, [device, device.name, devtype, fmt, str(device.size), label, mnt])
+        if device.type == "mdarray" and device.size == blivet.size.Size(0):
+            # broken MD array
+            # TRANSLATORS: size value for device with invalid/unknown size
+            devsize = _("unknown")
+        else:
+            devsize = str(device.size)
+
+        device_iter = self.partitions_list.append(parent_iter, [device, device.name, devtype, fmt, devsize, label, mnt])
 
         return device_iter
 

--- a/blivetgui/visualization/rectangle.py
+++ b/blivetgui/visualization/rectangle.py
@@ -29,6 +29,8 @@ from gi.repository import Gtk
 
 from ..i18n import _
 
+import blivet
+
 
 class Rectangle(Gtk.RadioButton):
     """ Rectangle object """
@@ -55,11 +57,18 @@ class Rectangle(Gtk.RadioButton):
                              "snapshot": ("camera-photo-symbolic", _("Snapshot")),
                              "nodisklabel": ("drive-harddisk-symbolic", _("Missing partition table")),
                              "protected": ("action-unavailable-symbolic", _("Device or format is write protected")),
-                             "cached": ("drive-harddisk-solidstate-symbolic", _("Cached device"))}
+                             "cached": ("drive-harddisk-solidstate-symbolic", _("Cached device")),
+                             "incomplete": ("dialog-warning-symbolic", _("Incomplete device"))}
+
+        if self.device.size == blivet.size.Size(0):
+            # TRANSLATORS: size value for device with invalid/unknown size
+            devsize = _("unknown")
+        else:
+            devsize = str(self.device.size)
 
         if label:
             label_device = Gtk.Label(justify=Gtk.Justification.CENTER,
-                                     label="<small>%s\n%s</small>" % (self.device.name, str(self.device.size)),
+                                     label="<small>%s\n%s</small>" % (self.device.name, devsize),
                                      use_markup=True, name="dark")
 
             hbox.pack_start(child=label_device, expand=True, fill=True, padding=0)
@@ -105,5 +114,8 @@ class Rectangle(Gtk.RadioButton):
 
         if self.device.type in ("lvmlv", "lvmthinpool") and self.device.cached:
             properties.append("cached")
+
+        if self.device.type in ("mdarray", "lvmvg") and not self.device.complete:
+            properties.append("incomplete")
 
         return properties

--- a/po/blivet-gui.pot
+++ b/po/blivet-gui.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-20 14:36+0200\n"
+"POT-Creation-Date: 2025-09-18 16:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -336,6 +336,13 @@ msgstr ""
 
 #: ../blivetgui/list_devices.py:134 ../blivetgui/dialogs/add_dialog.py:392
 msgid "Stratis Pool"
+msgstr ""
+
+#. broken MD array
+#. TRANSLATORS: size value for device with invalid/unknown size
+#: ../blivetgui/list_partitions.py:167
+#: ../blivetgui/visualization/rectangle.py:65
+msgid "unknown"
 msgstr ""
 
 #: ../blivetgui/loading_window.py:48
@@ -948,40 +955,44 @@ msgstr ""
 msgid "Passphrases don't match."
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:50
+#: ../blivetgui/visualization/rectangle.py:52
 msgid "Group device"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:51
+#: ../blivetgui/visualization/rectangle.py:53
 msgid "LiveUSB device"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:52
+#: ../blivetgui/visualization/rectangle.py:54
 msgid "Encrypted device (locked)"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:53
+#: ../blivetgui/visualization/rectangle.py:55
 msgid "Encrypted device (unlocked)"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:54
+#: ../blivetgui/visualization/rectangle.py:56
 msgid "Empty device"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:55
+#: ../blivetgui/visualization/rectangle.py:57
 msgid "Snapshot"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:56
+#: ../blivetgui/visualization/rectangle.py:58
 msgid "Missing partition table"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:57
+#: ../blivetgui/visualization/rectangle.py:59
 msgid "Device or format is write protected"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:58
+#: ../blivetgui/visualization/rectangle.py:60
 msgid "Cached device"
+msgstr ""
+
+#: ../blivetgui/visualization/rectangle.py:61
+msgid "Incomplete device"
 msgstr ""
 
 #: ../data/ui/about_dialog.ui:11

--- a/tests/blivetgui_tests/list_partitions_test.py
+++ b/tests/blivetgui_tests/list_partitions_test.py
@@ -7,6 +7,7 @@ from blivet.size import Size
 
 from blivetgui.list_partitions import ListPartitions
 from blivetgui.gui_utils import locate_ui_file
+from blivetgui.i18n import _
 
 import os
 
@@ -309,6 +310,20 @@ class ListPartitionsTest(unittest.TestCase):
         self.assertEqual(self.list_partitions.partitions_list.get_value(child_it, 4), str(device.size))
         self.assertEqual(self.list_partitions.partitions_list.get_value(child_it, 5), 15 * "a" + "...")
         self.assertEqual(self.list_partitions.partitions_list.get_value(child_it, 6), "")
+
+        # broken MD raid -- size should be set to "unknown"
+        fmt = MagicMock(type=None, mountable=False, label=None)
+        fmt.configure_mock(name="Unknown")
+        device = MagicMock(type="mdarray", size=Size(0), format=fmt)
+        device.configure_mock(name="brokenmd")
+
+        it = self.list_partitions._add_to_store(device)
+        self.assertEqual(self.list_partitions.partitions_list.get_value(it, 1), device.name)
+        self.assertEqual(self.list_partitions.partitions_list.get_value(it, 2), "raid")
+        self.assertIsNone(self.list_partitions.partitions_list.get_value(it, 3))
+        self.assertEqual(self.list_partitions.partitions_list.get_value(it, 4), _("unknown"))
+        self.assertEqual(self.list_partitions.partitions_list.get_value(it, 5), "")
+        self.assertIsNone(self.list_partitions.partitions_list.get_value(it, 6))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This can be confusing especially for broken MD arrays where the size of the device is 0. In this case it makes more sense to show size as "unknown". We are alsi showing a special warning icon for all incomplete devices.

Fixes: #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an “Incomplete device” status with a warning icon in the visualization.

- Bug Fixes
  - MD RAID arrays with invalid/unknown size now display “unknown” instead of “0” in lists and visualizations.

- Tests
  - Added tests covering MD RAID devices with unknown size.

- Chores
  - Updated translation template with new strings (“unknown”, “Incomplete device”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->