### PR TITLE
Hide advanced options when adding partitions on GPT

### DIFF
--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -965,8 +965,14 @@ class AddDialog(Gtk.Dialog):
         self.add_size_area()
 
         if device_type == "partition":
-            self.show_widgets(["label", "fs", "encrypt", "mountpoint", "size", "advanced"])
+            self.show_widgets(["label", "fs", "encrypt", "mountpoint", "size"])
             self.hide_widgets(["name", "mdraid"])
+
+            # show advanced widgets (partition type selection) only for msdos partition table
+            if self.selected_parent.format.type == "disklabel" and self.selected_parent.format.label_type == "msdos":
+                self.show_widgets(["advanced"])
+            else:
+                self.hide_widgets(["advanced"])
 
         elif device_type == "lvm":
             self.show_widgets(["encrypt", "name", "size", "advanced"])


### PR DESCRIPTION
Selecting partition type makes sense only on MSDOS.

Fixes: #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add dialog now shows advanced partition options only when the selected disk uses an msdos partition table; options are hidden for other types (e.g., GPT) to streamline the UI.
* **Tests**
  * Expanded test coverage to simulate disks with different partition table types (msdos, GPT) to validate conditional visibility of advanced options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->