### PR TITLE
Do not pass -f to mkfs.ntfs

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -978,15 +978,9 @@ class BlivetUtils(object):
             return actions
 
         if fmt_type is not None:
-            if fmt_type == "ntfs":
-                fmt_options = "-f"
-            else:
-                fmt_options = ""
-
             new_fmt = blivet.formats.get_format(fmt_type=user_input.filesystem,
                                                 label=user_input.label,
-                                                mountpoint=user_input.mountpoint,
-                                                create_options=fmt_options)
+                                                mountpoint=user_input.mountpoint)
             return [blivet.deviceaction.ActionCreateFormat(device, new_fmt)]
 
     def _create_btrfs_format(self, user_input, device):


### PR DESCRIPTION
This is no longer needed since blivet switched to libblockdev for filesystem operation, libblockdev uses the -f/--fast option by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - NTFS formatting now uses default settings, aligning behavior with other filesystems and reducing unexpected results during volume creation.
- Refactor
  - Simplified the format creation flow by removing filesystem-specific branching, improving maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->