### PR TITLE
Make group devices sub-views more discoverable

### DIFF
--- a/blivetgui/actions_menu.py
+++ b/blivetgui/actions_menu.py
@@ -38,7 +38,8 @@ class ActionsMenu:
         """ Create popup menu
         """
 
-        items = [("add", self.blivet_gui.add_device),
+        items = [("open", self.blivet_gui.open_group_device),
+                 ("add", self.blivet_gui.add_device),
                  ("delete", self.blivet_gui.delete_selected_partition),
                  ("resize", self.blivet_gui.resize_device),
                  ("rename", self.blivet_gui.rename_device),

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -268,6 +268,10 @@ class BlivetGUI:
     def _raise_exception(self, exception, traceback):
         raise exception.with_traceback(traceback)
 
+    def open_group_device(self, _widget=None):
+        """ Open selected group device (navigate into it) """
+        self.switch_device_view(self.list_partitions.selected_partition[0])
+
     def switch_device_view(self, device):
         if not (device.is_disk or device.type in ("lvmvg", "btrfs volume", "mdarray", "stratis pool")):
             raise ValueError

--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -341,6 +341,9 @@ class ListPartitions:
         if self._allow_set_partition_table(device):
             self.blivet_gui.activate_device_actions(["partitiontable"])
 
+        if device.type in ("lvmvg", "btrfs volume", "mdarray", "stratis pool"):
+            self.blivet_gui.activate_device_actions(["open"])
+
         if device.type == "lvmvg":
             self.blivet_gui.activate_device_actions(["parents"])
 

--- a/data/ui/blivet-gui.ui
+++ b/data/ui/blivet-gui.ui
@@ -8,6 +8,20 @@
     <property name="can-focus">False</property>
     <property name="accel-group">accelgroup</property>
     <child>
+      <object class="GtkMenuItem" id="menuitem_open">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Open</property>
+        <property name="use-underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkSeparatorMenuItem">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+      </object>
+    </child>
+    <child>
       <object class="GtkMenuItem" id="menuitem_add">
         <property name="visible">True</property>
         <property name="can-focus">False</property>

--- a/po/blivet-gui.pot
+++ b/po/blivet-gui.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-10 09:43+0100\n"
+"POT-Creation-Date: 2026-02-21 16:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,133 +18,133 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../blivetgui/blivetgui.py:295
+#: ../blivetgui/blivetgui.py:302
 msgid "Failed to resize the device:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:307
+#: ../blivetgui/blivetgui.py:314
 #, python-brace-format
 msgid "resize {name} {type}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:319
+#: ../blivetgui/blivetgui.py:326
 msgid "Failed to rename the device:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:331
+#: ../blivetgui/blivetgui.py:338
 #, python-brace-format
 msgid "rename {name} {type}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:350
+#: ../blivetgui/blivetgui.py:357
 msgid "Failed to format the device:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:364
+#: ../blivetgui/blivetgui.py:371
 #, python-brace-format
 msgid "format {name} {type}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:377
+#: ../blivetgui/blivetgui.py:384
 msgid "Failed to edit the LVM2 Volume Group:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:392
+#: ../blivetgui/blivetgui.py:399
 #, python-brace-format
 msgid "edit {name} {type}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:421
+#: ../blivetgui/blivetgui.py:428
 msgid "Failed to change filesystem label on the device:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:426
+#: ../blivetgui/blivetgui.py:433
 #, python-brace-format
 msgid "change filesystem label of {name} {type}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:442
+#: ../blivetgui/blivetgui.py:449
 #, python-brace-format
 msgid ""
 "{name} is not complete. It is not possible to add new LVs to VG with missing "
 "PVs."
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:447
+#: ../blivetgui/blivetgui.py:454
 msgid "Not enough free space for a new LVM Volume Group."
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:453
+#: ../blivetgui/blivetgui.py:460
 #, python-brace-format
 msgid ""
 "Disk {name} already reached maximum allowed number of primary partitions for "
 "{label} disklabel."
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:463
+#: ../blivetgui/blivetgui.py:470
 msgid "Failed to add disklabel:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:476
+#: ../blivetgui/blivetgui.py:483
 #, python-brace-format
 msgid "create new disklabel on {name}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:528
+#: ../blivetgui/blivetgui.py:535
 msgid "Failed to add the device:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:543
+#: ../blivetgui/blivetgui.py:550
 #, python-brace-format
 msgid "add {size} {type} device"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:587
+#: ../blivetgui/blivetgui.py:594
 msgid "Failed to delete the device:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:602
+#: ../blivetgui/blivetgui.py:609
 #, python-brace-format
 msgid "delete partition {name}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:643
+#: ../blivetgui/blivetgui.py:650
 msgid "Failed to perform the actions:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:687
+#: ../blivetgui/blivetgui.py:694
 msgid "Confirm scheduled actions"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:688
+#: ../blivetgui/blivetgui.py:695
 msgid "Are you sure you want to perform scheduled actions?"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:729
+#: ../blivetgui/blivetgui.py:736
 #, python-brace-format
 msgid ""
 "Unmount of '{mountpoint}' failed. Are you sure the device is not in use?"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:751
+#: ../blivetgui/blivetgui.py:758
 msgid "Unlocking failed. Are you sure provided password is correct?"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:801 ../data/ui/blivet-gui.ui:678
+#: ../blivetgui/blivetgui.py:808 ../data/ui/blivet-gui.ui:692
 msgid "Quit"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:804
+#: ../blivetgui/blivetgui.py:811
 msgid "blivet-gui is already running"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:805
+#: ../blivetgui/blivetgui.py:812
 msgid ""
 "Another instance of blivet-gui is already running.\n"
 "Only one instance of blivet-gui can run at the same time."
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:807
+#: ../blivetgui/blivetgui.py:814
 msgid ""
 "If your previous instance of blivet-gui crashed, please make sure that the "
 "<i>blivet-gui-daemon</i> process was terminated too.\n"
@@ -155,24 +155,24 @@ msgid ""
 "command to force quit it."
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:839
+#: ../blivetgui/blivetgui.py:846
 msgid "Failed to init blivet:"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:846
+#: ../blivetgui/blivetgui.py:853
 msgid "Quit blivet-gui"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:848
+#: ../blivetgui/blivetgui.py:855
 msgid "Ignore disk and continue"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:851
+#: ../blivetgui/blivetgui.py:858
 #, python-brace-format
 msgid "Error: {error}"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:852
+#: ../blivetgui/blivetgui.py:859
 #, python-brace-format
 msgid ""
 "Blivet-gui can't use the <b>{name}</b> disk due to a corrupted/unknown "
@@ -181,19 +181,19 @@ msgid ""
 "this disk."
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:888
+#: ../blivetgui/blivetgui.py:895
 msgid "Confirm reload storage"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:889
+#: ../blivetgui/blivetgui.py:896
 msgid "There are pending operations. Are you sure you want to continue?"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:920
+#: ../blivetgui/blivetgui.py:927
 msgid "Are you sure you want to quit?"
 msgstr ""
 
-#: ../blivetgui/blivetgui.py:921
+#: ../blivetgui/blivetgui.py:928
 msgid ""
 "There are pending operations. Are you sure you want to quit blivet-gui now?"
 msgstr ""
@@ -286,7 +286,7 @@ msgid ""
 msgstr ""
 
 #: ../blivetgui/list_actions.py:69 ../blivetgui/list_actions.py:118
-#: ../blivetgui/list_actions.py:140 ../data/ui/blivet-gui.ui:633
+#: ../blivetgui/list_actions.py:140 ../data/ui/blivet-gui.ui:647
 msgid "No pending actions"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgstr ""
 #. broken MD array
 #. TRANSLATORS: size value for device with invalid/unknown size
 #: ../blivetgui/list_partitions.py:166
-#: ../blivetgui/visualization/rectangle.py:64
+#: ../blivetgui/visualization/rectangle.py:66
 msgid "unknown"
 msgstr ""
 
@@ -393,8 +393,10 @@ msgid ""
 "<i>{action}</i>"
 msgstr ""
 
-#: ../blivetgui/communication/client.py:300
-#: ../blivetgui/communication/client.py:317
+#: ../blivetgui/communication/client.py:284
+#: ../blivetgui/communication/client.py:292
+#: ../blivetgui/communication/client.py:313
+#: ../blivetgui/communication/client.py:330
 msgid "Failed to connect to blivet-gui-daemon"
 msgstr ""
 
@@ -499,7 +501,7 @@ msgstr ""
 #: ../blivetgui/dialogs/add_dialog.py:457
 #: ../blivetgui/dialogs/edit_dialog.py:628
 #: ../blivetgui/dialogs/edit_dialog.py:677
-#: ../blivetgui/dialogs/edit_dialog.py:739 ../data/ui/blivet-gui.ui:485
+#: ../blivetgui/dialogs/edit_dialog.py:739 ../data/ui/blivet-gui.ui:499
 #: ../data/ui/cache_area.ui:76
 msgid "Device"
 msgstr ""
@@ -507,7 +509,7 @@ msgstr ""
 #: ../blivetgui/dialogs/add_dialog.py:458
 #: ../blivetgui/dialogs/edit_dialog.py:629
 #: ../blivetgui/dialogs/edit_dialog.py:678
-#: ../blivetgui/dialogs/edit_dialog.py:740 ../data/ui/blivet-gui.ui:498
+#: ../blivetgui/dialogs/edit_dialog.py:740 ../data/ui/blivet-gui.ui:512
 #: ../data/ui/cache_area.ui:87
 msgid "Type"
 msgstr ""
@@ -515,7 +517,7 @@ msgstr ""
 #: ../blivetgui/dialogs/add_dialog.py:459
 #: ../blivetgui/dialogs/edit_dialog.py:630
 #: ../blivetgui/dialogs/edit_dialog.py:679
-#: ../blivetgui/dialogs/edit_dialog.py:741 ../data/ui/blivet-gui.ui:520
+#: ../blivetgui/dialogs/edit_dialog.py:741 ../data/ui/blivet-gui.ui:534
 msgid "Size"
 msgstr ""
 
@@ -928,61 +930,70 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:80 ../data/ui/blivet-gui.ui:692
+#: ../blivetgui/dialogs/other_dialogs.py:80 ../data/ui/blivet-gui.ui:706
 msgid "System Information"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:141
+#: ../blivetgui/dialogs/other_dialogs.py:144
 msgid "Version Information"
 msgstr ""
 
 #. blivet-gui version
-#: ../blivetgui/dialogs/other_dialogs.py:144 ../data/ui/blivet-gui.ui:255
+#: ../blivetgui/dialogs/other_dialogs.py:147 ../data/ui/blivet-gui.ui:269
 msgid "blivet-gui"
 msgstr ""
 
 #. pylint: disable=broad-except
-#: ../blivetgui/dialogs/other_dialogs.py:149
-#: ../blivetgui/dialogs/other_dialogs.py:151
+#: ../blivetgui/dialogs/other_dialogs.py:152
+#: ../blivetgui/dialogs/other_dialogs.py:154
 msgid "blivet"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:151
+#: ../blivetgui/dialogs/other_dialogs.py:154
 msgid "Unknown"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:158
+#: ../blivetgui/dialogs/other_dialogs.py:161
 msgid "Startup Options"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:164
+#: ../blivetgui/dialogs/other_dialogs.py:167
 msgid "None (all disks)"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:165
+#: ../blivetgui/dialogs/other_dialogs.py:168
 msgid "Exclusive disks"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:167
+#: ../blivetgui/dialogs/other_dialogs.py:170
 msgid "Selection of disks blivet-gui is allowed to operate with"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:171
+#: ../blivetgui/dialogs/other_dialogs.py:174
 msgid "Advanced device information"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:172
+#: ../blivetgui/dialogs/other_dialogs.py:175
 msgid "Yes"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:172
+#: ../blivetgui/dialogs/other_dialogs.py:175
 msgid "No"
 msgstr ""
 
-#: ../blivetgui/dialogs/other_dialogs.py:173
+#: ../blivetgui/dialogs/other_dialogs.py:176
 msgid ""
 "Whether gathering all information about devices is enabled, even if it "
 "requires potentially dangerous operations like mounting or a filesystem check"
+msgstr ""
+
+#: ../blivetgui/dialogs/other_dialogs.py:192
+msgid ""
+"<b>Warning:</b> Some information about Btrfs devices might be missing "
+"because there are unmounted Btrfs devices on the system. Gathering "
+"information about these devices requires mounting them which is not enabled "
+"by default.\n"
+"To enable this, start blivet-gui with the <tt>--auto-dev-updates</tt> option."
 msgstr ""
 
 #: ../blivetgui/dialogs/size_chooser.py:215
@@ -1016,45 +1027,97 @@ msgstr ""
 msgid "Passphrases don't match."
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:51
+#: ../blivetgui/visualization/rectangle.py:52
 msgid "Group device"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:52
+#: ../blivetgui/visualization/rectangle.py:53
 msgid "LiveUSB device"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:53
+#: ../blivetgui/visualization/rectangle.py:54
 msgid "Encrypted device (locked)"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:54
+#: ../blivetgui/visualization/rectangle.py:55
 msgid "Encrypted device (unlocked)"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:55
+#: ../blivetgui/visualization/rectangle.py:56
 msgid "Empty device"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:56
+#: ../blivetgui/visualization/rectangle.py:57
 msgid "Snapshot"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:57
+#: ../blivetgui/visualization/rectangle.py:58
 msgid "Missing partition table"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:58
+#: ../blivetgui/visualization/rectangle.py:59
 msgid "Device or format is write protected"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:59
+#: ../blivetgui/visualization/rectangle.py:60
 msgid "Cached device"
 msgstr ""
 
-#: ../blivetgui/visualization/rectangle.py:60
+#: ../blivetgui/visualization/rectangle.py:61
 msgid "Incomplete device"
 msgstr ""
+
+#: ../blivetgui/visualization/rectangle.py:62
+msgid "Missing subvolume information"
+msgstr ""
+
+#: ../blivetgui/visualization/rectangle.py:104
+msgid "LVM2 Volume Group — double-click to view Logical Volumes"
+msgstr ""
+
+#: ../blivetgui/visualization/rectangle.py:105
+msgid "Btrfs Volume — double-click to view subvolumes"
+msgstr ""
+
+#: ../blivetgui/visualization/rectangle.py:106
+msgid "RAID Array — double-click to view contents"
+msgstr ""
+
+#: ../blivetgui/visualization/rectangle.py:107
+msgid "Stratis Pool — double-click to view filesystems"
+msgstr ""
+
+#. TRANSLATORS: count of Logical Volumes in a Volume Group, e.g. "3 logical volumes"
+#: ../blivetgui/visualization/rectangle.py:117
+#, python-brace-format
+msgid "{count} logical volume"
+msgid_plural "{count} logical volumes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: count of subvolumes in a Btrfs volume, e.g. "3 subvolumes"
+#: ../blivetgui/visualization/rectangle.py:120
+#, python-brace-format
+msgid "{count} subvolume"
+msgid_plural "{count} subvolumes"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: count of partitions on a RAID array, e.g. "3 partitions"
+#: ../blivetgui/visualization/rectangle.py:123
+#, python-brace-format
+msgid "{count} partition"
+msgid_plural "{count} partitions"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: count of filesystems in a Stratis pool, e.g. "3 filesystems"
+#: ../blivetgui/visualization/rectangle.py:126
+#, python-brace-format
+msgid "{count} filesystem"
+msgid_plural "{count} filesystems"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../data/ui/about_dialog.ui:11
 msgid "Copyright © Red Hat Inc."
@@ -1073,139 +1136,143 @@ msgid "Select new partition table type:"
 msgstr ""
 
 #: ../data/ui/blivet-gui.ui:14
+msgid "Open"
+msgstr ""
+
+#: ../data/ui/blivet-gui.ui:28
 msgid "New"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:23
+#: ../data/ui/blivet-gui.ui:37
 msgid "Delete"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:32
+#: ../data/ui/blivet-gui.ui:46
 msgid "Edit"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:42 ../data/ui/blivet-gui.ui:130
+#: ../data/ui/blivet-gui.ui:56 ../data/ui/blivet-gui.ui:144
 msgid "Resize"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:50 ../data/ui/blivet-gui.ui:138
+#: ../data/ui/blivet-gui.ui:64 ../data/ui/blivet-gui.ui:152
 msgid "Rename"
 msgstr ""
 
 #. Edit format (e.g. delete existing and create a new one) on selected device.
-#: ../data/ui/blivet-gui.ui:58 ../data/ui/blivet-gui.ui:146
+#: ../data/ui/blivet-gui.ui:72 ../data/ui/blivet-gui.ui:160
 msgctxt "Menu|Edit"
 msgid "Format"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:66 ../data/ui/blivet-gui.ui:154
+#: ../data/ui/blivet-gui.ui:80 ../data/ui/blivet-gui.ui:168
 msgid "Modify parents"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:74 ../data/ui/blivet-gui.ui:162
+#: ../data/ui/blivet-gui.ui:88 ../data/ui/blivet-gui.ui:176
 #: ../data/ui/mountpoint_dialog.ui:7
 msgid "Set mountpoint"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:82 ../data/ui/blivet-gui.ui:170
+#: ../data/ui/blivet-gui.ui:96 ../data/ui/blivet-gui.ui:184
 msgid "Set label"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:90 ../data/ui/blivet-gui.ui:178
+#: ../data/ui/blivet-gui.ui:104 ../data/ui/blivet-gui.ui:192
 msgid "Set partition table"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:102 ../data/ui/unmount_dialog.ui:15
+#: ../data/ui/blivet-gui.ui:116 ../data/ui/unmount_dialog.ui:15
 msgid "Unmount"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:110
+#: ../data/ui/blivet-gui.ui:124
 msgid "Unlock"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:118
+#: ../data/ui/blivet-gui.ui:132
 msgid "Information"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:290 ../data/ui/blivet-gui.ui:302
-#: ../data/ui/blivet-gui.ui:851 ../data/ui/blivet-gui.ui:862
-#: ../data/ui/blivet-gui.ui:873
+#: ../data/ui/blivet-gui.ui:304 ../data/ui/blivet-gui.ui:316
+#: ../data/ui/blivet-gui.ui:865 ../data/ui/blivet-gui.ui:876
+#: ../data/ui/blivet-gui.ui:887
 msgid "column"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:364
+#: ../data/ui/blivet-gui.ui:378
 msgctxt "ActionsToolbar|Add"
 msgid "Add new device"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:380
+#: ../data/ui/blivet-gui.ui:394
 msgctxt "ActionsToolbar|Delete"
 msgid "Delete selected device"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:396
+#: ../data/ui/blivet-gui.ui:410
 msgctxt "ActionsToolbar|Edit"
 msgid "Edit selected device"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:422
+#: ../data/ui/blivet-gui.ui:436
 msgctxt "ActionsToolbar|Unmount"
 msgid "Unmount selected device"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:437
+#: ../data/ui/blivet-gui.ui:451
 msgctxt "ActionsToolbar|Decrypt"
 msgid "Unlock/Open selected device"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:452
+#: ../data/ui/blivet-gui.ui:466
 msgctxt "ActionsToolbar|Info"
 msgid "Display information about selected device"
 msgstr ""
 
 #. Format (filesystem) type of selected device.
-#: ../data/ui/blivet-gui.ui:509
+#: ../data/ui/blivet-gui.ui:523
 msgctxt "LogicalView|Column"
 msgid "Format"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:531
+#: ../data/ui/blivet-gui.ui:545
 msgid "Label"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:542
+#: ../data/ui/blivet-gui.ui:556
 msgid "Mountpoint"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:566
+#: ../data/ui/blivet-gui.ui:580
 msgid "Logical View"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:589
+#: ../data/ui/blivet-gui.ui:603
 msgid "Physical View"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:662
+#: ../data/ui/blivet-gui.ui:676
 msgid "Reload Storage"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:670
+#: ../data/ui/blivet-gui.ui:684
 msgid "Queued Actions"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:700
+#: ../data/ui/blivet-gui.ui:714
 msgid "About blivet-gui"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:752
+#: ../data/ui/blivet-gui.ui:766
 msgid "Apply pending actions"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:768
+#: ../data/ui/blivet-gui.ui:782
 msgid "Clear scheduled actions"
 msgstr ""
 
-#: ../data/ui/blivet-gui.ui:784
+#: ../data/ui/blivet-gui.ui:798
 msgid "Undo last action"
 msgstr ""
 

--- a/tests/blivetgui_tests/visualization_test.py
+++ b/tests/blivetgui_tests/visualization_test.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import MagicMock
+
+from blivet.size import Size
+
+from blivetgui.visualization.rectangle import Rectangle
+
+import os
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+
+
+def _mock_device(dev_type, name="test", size=Size("10 GiB"), children=None, **kwargs):
+    """ Create a mock device with common defaults """
+    if children is None:
+        children = []
+    fmt = kwargs.pop("format", MagicMock(type=None, exists=True, status=False))
+    is_disk = kwargs.pop("is_disk", False)
+    protected = kwargs.pop("protected", False)
+    parents = kwargs.pop("parents", [])
+
+    device = MagicMock(type=dev_type, size=size, children=children,
+                       format=fmt, is_disk=is_disk, protected=protected,
+                       parents=parents, **kwargs)
+    device.configure_mock(name=name)
+    return device
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class RectangleChildCountTest(unittest.TestCase):
+
+    def _create_rectangle(self, device):
+        blivet_gui = MagicMock(auto_dev_updates_warning=False)
+        rect = Rectangle("", None, 200, 50, device, blivet_gui)
+        return rect
+
+    def _get_label_text(self, rect):
+        """ Extract the text from the label widget inside the rectangle """
+        hbox = rect.get_child()
+        for child in hbox.get_children():
+            if isinstance(child, Gtk.Label):
+                return child.get_text()
+        return None
+
+    def test_child_count(self):
+        # VG with 3 LVs
+        device = _mock_device("lvmvg", name="myvg", children=[MagicMock() for _ in range(3)])
+        rect = self._create_rectangle(device)
+        label = self._get_label_text(rect)
+        self.assertIn("myvg", label)
+        self.assertIn("3 logical volumes", label)
+
+        # VG with one LV
+        device = _mock_device("lvmvg", name="myvg", children=[MagicMock()])
+        rect = self._create_rectangle(device)
+        label = self._get_label_text(rect)
+        self.assertIn("1 logical volume", label)
+
+        # VG without LVs
+        device = _mock_device("lvmvg", name="myvg", children=[])
+        rect = self._create_rectangle(device)
+        label = self._get_label_text(rect)
+        self.assertIn("0 logical volumes", label)
+
+        # btrfs volume
+        children = [MagicMock() for _ in range(2)]
+        device = _mock_device("btrfs volume", name="btrfs1", children=children,
+                              subvolumes=[])
+        rect = self._create_rectangle(device)
+        label = self._get_label_text(rect)
+        self.assertIn("btrfs1", label)
+        self.assertIn("2 subvolumes", label)
+
+        # other
+        device = _mock_device("partition", name="sda1",
+                              format=MagicMock(type="ext4", exists=True, status=False))
+        rect = self._create_rectangle(device)
+        label = self._get_label_text(rect)
+        self.assertIn("sda1", label)
+        self.assertNotIn("logical volume", label)
+        self.assertNotIn("subvolume", label)
+        self.assertNotIn("filesystem", label)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add visual cues and navigation aids for group devices (LVM VGs, Btrfs volumes, MD arrays, Stratis pools):

- Show type-specific tooltip on group icon with double-click hint (e.g. "LVM2 Volume Group — double-click to view Logical Volumes")
- Display child count in rectangle label for group devices (e.g. "myvg (3 logical volumes)")
- Add "Open" right-click menu item for navigating into group devices
- Add GUI tests for the new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Open" menu action to navigate into group devices (LVM volumes, Btrfs volumes, RAID arrays, Stratis pools).
  * Device labels now display child counts for group devices.
  * Improved tooltips for group device types.

* **Tests**
  * Added test coverage for device label display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->