### PR TITLE
Split parent edit dialog into two for separate adding and removing parent devices

### DIFF
--- a/blivetgui/actions_menu.py
+++ b/blivetgui/actions_menu.py
@@ -48,7 +48,8 @@ class ActionsMenu:
                  ("unmount", self.blivet_gui.umount_partition),
                  ("decrypt", self.blivet_gui.decrypt_device),
                  ("info", self.blivet_gui.device_information),
-                 ("parents", self.blivet_gui.edit_lvmvg),
+                 ("add_parent", self.blivet_gui.add_lvmvg_parent),
+                 ("remove_parent", self.blivet_gui.remove_lvmvg_parent),
                  ("mountpoint", self.blivet_gui.set_mountpoint),
                  ("partitiontable", self.blivet_gui.set_partition_table)]
 

--- a/blivetgui/actions_toolbar.py
+++ b/blivetgui/actions_toolbar.py
@@ -68,7 +68,8 @@ class DeviceToolbar(BlivetGUIToolbar):
                  ("unmount", "clicked", self.blivet_gui.umount_partition),
                  ("decrypt", "clicked", self.blivet_gui.decrypt_device),
                  ("info", "clicked", self.blivet_gui.device_information),
-                 ("parents", "activate", self.blivet_gui.edit_lvmvg),
+                 ("add_parent", "activate", self.blivet_gui.add_lvmvg_parent),
+                 ("remove_parent", "activate", self.blivet_gui.remove_lvmvg_parent),
                  ("mountpoint", "activate", self.blivet_gui.set_mountpoint),
                  ("label", "activate", self.blivet_gui.edit_label),
                  ("partitiontable", "activate", self.blivet_gui.set_partition_table)]

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -374,13 +374,43 @@ class BlivetGUI:
                 self._handle_user_change()
                 self.update_partitions_view()
 
-    def edit_lvmvg(self, _widget=None):
-        """ Edit selected lvmvg
+    def add_lvmvg_parent(self, _widget=None):
+        """ Add a parent (PV) to the selected VG
         """
 
         device = self.list_partitions.selected_partition[0]
-        dialog = edit_dialog.LVMEditDialog(self.main_window, device,
-                                           self.client.remote_call("get_free_info"))
+        dialog = edit_dialog.LVMAddDialog(self.main_window, device,
+                                          self.client.remote_call("get_free_info"))
+        message = _("Failed to edit the LVM2 Volume Group:")
+        response = self.run_dialog(dialog)
+
+        if response == Gtk.ResponseType.OK:
+            user_input = dialog.get_selection()
+            result = self.client.remote_call("edit_lvmvg_device", user_input)
+
+            if not result.success:
+                if not result.exception:
+                    self.show_error_dialog(result.message)
+                else:
+                    self._reraise_exception(result.exception, result.traceback, message,
+                                            dialog_window=dialog)
+            else:
+                if result.actions:
+                    action_str = _("edit {name} {type}").format(name=device.name, type=device.type)
+                    self.list_actions.append("edit", action_str, result.actions)
+
+            self._handle_user_change()
+            self.update_partitions_view()
+
+        dialog.destroy()
+        return
+
+    def remove_lvmvg_parent(self, _widget=None):
+        """ Remove a parent (PV) from the selected VG
+        """
+
+        device = self.list_partitions.selected_partition[0]
+        dialog = edit_dialog.LVMRemoveDialog(self.main_window, device)
         message = _("Failed to edit the LVM2 Volume Group:")
         response = self.run_dialog(dialog)
 

--- a/blivetgui/dialogs/edit_dialog.py
+++ b/blivetgui/dialogs/edit_dialog.py
@@ -665,10 +665,10 @@ class LVMAddDialog(Gtk.Dialog):
 
         if self.add_store:
             for row in self.add_store:
-                if row[2] and row[0].type == "partition":
+                if row[2] and row[4] == "lvmpv":
                     parents_list.append(row[0])
 
-                if row[2] and row[0].type == "disk":
+                if row[2] and row[4] == "free region":
                     parents_list.append(row[1])
 
         return ProxyDataContainer(edit_device=self.edited_device,

--- a/blivetgui/dialogs/edit_dialog.py
+++ b/blivetgui/dialogs/edit_dialog.py
@@ -607,35 +607,9 @@ class LVMAddDialog(Gtk.Dialog):
         box = self.get_content_area()
         box.add(self.grid)
 
-        self._add_parent_list()
         self.add_store = self._add_available_parents()
 
         self.show_all()
-
-    def _add_parent_list(self):
-
-        parents_store = Gtk.ListStore(str, str, str)
-
-        for parent in self.edited_device.parents:
-            parents_store.append([parent.name, "lvmpv", str(parent.size)])
-
-        parents_view = Gtk.TreeView(model=parents_store)
-        renderer_text = Gtk.CellRendererText()
-
-        column_name = Gtk.TreeViewColumn(_("Device"), renderer_text, text=0)
-        column_type = Gtk.TreeViewColumn(_("Type"), renderer_text, text=1)
-        column_size = Gtk.TreeViewColumn(_("Size"), renderer_text, text=2)
-
-        parents_view.append_column(column_name)
-        parents_view.append_column(column_type)
-        parents_view.append_column(column_size)
-
-        parents_view.set_headers_visible(True)
-
-        label_list = Gtk.Label(label=_("Parent devices:"), xalign=1)
-
-        self.grid.attach(label_list, 0, 1, 1, 1)
-        self.grid.attach(parents_view, 1, 1, 3, 3)
 
     def _add_available_parents(self):
 
@@ -666,10 +640,11 @@ class LVMAddDialog(Gtk.Dialog):
 
         parents_view.set_headers_visible(True)
 
-        label_list = Gtk.Label(label=_("Available devices:"), xalign=1)
+        label_list = Gtk.Label(label=_("Select devices to be added to {name}:").format(name=self.edited_device.name),
+                               xalign=0)
 
-        self.grid.attach(label_list, 0, 5, 1, 1)
-        self.grid.attach(parents_view, 1, 5, 4, 3)
+        self.grid.attach(label_list, 0, 5, 5, 1)
+        self.grid.attach(parents_view, 0, 6, 5, 3)
 
         for ftype, free in self.free_info:
             if ftype == "lvmpv":
@@ -732,35 +707,9 @@ class LVMRemoveDialog(Gtk.Dialog):
         box = self.get_content_area()
         box.add(self.grid)
 
-        self._add_parent_list()
         self.remove_store = self._add_removable_parents()
 
         self.show_all()
-
-    def _add_parent_list(self):
-
-        parents_store = Gtk.ListStore(str, str, str)
-
-        for parent in self.edited_device.parents:
-            parents_store.append([parent.name, "lvmpv", str(parent.size)])
-
-        parents_view = Gtk.TreeView(model=parents_store)
-        renderer_text = Gtk.CellRendererText()
-
-        column_name = Gtk.TreeViewColumn(_("Device"), renderer_text, text=0)
-        column_type = Gtk.TreeViewColumn(_("Type"), renderer_text, text=1)
-        column_size = Gtk.TreeViewColumn(_("Size"), renderer_text, text=2)
-
-        parents_view.append_column(column_name)
-        parents_view.append_column(column_type)
-        parents_view.append_column(column_size)
-
-        parents_view.set_headers_visible(True)
-
-        label_list = Gtk.Label(label=_("Parent devices:"), xalign=1)
-
-        self.grid.attach(label_list, 0, 1, 1, 1)
-        self.grid.attach(parents_view, 1, 1, 3, 3)
 
     def _add_removable_parents(self):
 
@@ -797,10 +746,11 @@ class LVMRemoveDialog(Gtk.Dialog):
 
         parents_view.set_headers_visible(True)
 
-        label_list = Gtk.Label(label=_("Available devices:"), xalign=1)
+        label_list = Gtk.Label(label=_("Select a device to be removed from {name}:").format(name=self.edited_device.name),
+                               xalign=0)
 
-        self.grid.attach(label_list, 0, 5, 1, 1)
-        self.grid.attach(parents_view, 1, 5, 4, 3)
+        self.grid.attach(label_list, 0, 5, 5, 1)
+        self.grid.attach(parents_view, 0, 6, 5, 3)
 
         for pv in removable_pvs:
             parents_store.append([pv, None, False, pv.name, "lvmpv", str(pv.size)])

--- a/blivetgui/dialogs/edit_dialog.py
+++ b/blivetgui/dialogs/edit_dialog.py
@@ -573,8 +573,8 @@ class UnmountDialog:
         self.dialog.response(Gtk.ResponseType.ACCEPT)
 
 
-class LVMEditDialog(Gtk.Dialog):
-    """ Dialog window allowing user to edit lvmvg
+class LVMAddDialog(Gtk.Dialog):
+    """ Dialog window allowing user to add parents to a VG
     """
 
     def __init__(self, parent_window, edited_device, free_info):
@@ -584,6 +584,8 @@ class LVMEditDialog(Gtk.Dialog):
             :type parent_window: Gtk.Window
             :param edited_device: device selected to edit
             :type edited_device: class blivet.Device
+            :param free_info: available free PVs and disk regions
+            :type free_info: list of tuples
 
         """
 
@@ -594,12 +596,10 @@ class LVMEditDialog(Gtk.Dialog):
         Gtk.Dialog.__init__(self)
 
         self.set_transient_for(self.parent_window)
-        self.set_resizable(False)  # auto shrink after removing/hiding widgets
-        self.set_title(_("Edit device"))
+        self.set_resizable(False)
+        self.set_title(_("Add parent device"))
         self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                          Gtk.STOCK_OK, Gtk.ResponseType.OK)
-
-        self.widgets_dict = {}
 
         self.grid = Gtk.Grid(column_homogeneous=False, row_spacing=10, column_spacing=5)
         self.grid.set_border_width(10)
@@ -607,15 +607,12 @@ class LVMEditDialog(Gtk.Dialog):
         box = self.get_content_area()
         box.add(self.grid)
 
-        self.add_parent_list()
-        self.button_add, self.button_remove = self.add_toggle_buttons()
+        self._add_parent_list()
+        self.add_store = self._add_available_parents()
 
         self.show_all()
 
-        self.add_store = self.add_parents()
-        self.remove_store = self.remove_parents()
-
-    def add_parent_list(self):
+    def _add_parent_list(self):
 
         parents_store = Gtk.ListStore(str, str, str)
 
@@ -640,171 +637,189 @@ class LVMEditDialog(Gtk.Dialog):
         self.grid.attach(label_list, 0, 1, 1, 1)
         self.grid.attach(parents_view, 1, 1, 3, 3)
 
-    def add_toggle_buttons(self):
-
-        button_add = Gtk.ToggleButton(label=_("Add a parent"))
-        self.grid.attach(button_add, 0, 4, 1, 1)
-
-        button_remove = Gtk.ToggleButton(label=_("Remove a parent"))
-        self.grid.attach(button_remove, 1, 4, 1, 1)
-
-        button_add.connect("toggled", self.on_button_toggled, "add", button_remove)
-        button_remove.connect("toggled", self.on_button_toggled, "remove", button_add)
-
-        return button_add, button_remove
-
-    def add_parents(self):
+    def _add_available_parents(self):
 
         if len(self.free_info) == 0:
             label_none = Gtk.Label(label=_("There are currently no empty physical volumes or\n"
                                            "disks with enough free space to create one."))
             self.grid.attach(label_none, 0, 5, 4, 1)
 
-            self.widgets_dict["add"] = [label_none]
-
             return None
 
-        else:
-            parents_store = Gtk.ListStore(object, object, bool, str, str, str)
-            parents_view = Gtk.TreeView(model=parents_store)
+        parents_store = Gtk.ListStore(object, object, bool, str, str, str)
+        parents_view = Gtk.TreeView(model=parents_store)
 
-            renderer_toggle = Gtk.CellRendererToggle()
-            renderer_toggle.connect("toggled", self.on_cell_toggled, parents_store)
+        renderer_toggle = Gtk.CellRendererToggle()
+        renderer_toggle.connect("toggled", self._on_cell_toggled, parents_store)
 
-            renderer_text = Gtk.CellRendererText()
+        renderer_text = Gtk.CellRendererText()
 
-            column_toggle = Gtk.TreeViewColumn(_("Add?"), renderer_toggle, active=2)
-            column_name = Gtk.TreeViewColumn(_("Device"), renderer_text, text=3)
-            column_type = Gtk.TreeViewColumn(_("Type"), renderer_text, text=4)
-            column_size = Gtk.TreeViewColumn(_("Size"), renderer_text, text=5)
+        column_toggle = Gtk.TreeViewColumn(_("Add?"), renderer_toggle, active=2)
+        column_name = Gtk.TreeViewColumn(_("Device"), renderer_text, text=3)
+        column_type = Gtk.TreeViewColumn(_("Type"), renderer_text, text=4)
+        column_size = Gtk.TreeViewColumn(_("Size"), renderer_text, text=5)
 
-            parents_view.append_column(column_toggle)
-            parents_view.append_column(column_name)
-            parents_view.append_column(column_type)
-            parents_view.append_column(column_size)
+        parents_view.append_column(column_toggle)
+        parents_view.append_column(column_name)
+        parents_view.append_column(column_type)
+        parents_view.append_column(column_size)
 
-            parents_view.set_headers_visible(True)
+        parents_view.set_headers_visible(True)
 
-            label_list = Gtk.Label(label=_("Available devices:"), xalign=1)
+        label_list = Gtk.Label(label=_("Available devices:"), xalign=1)
 
-            self.grid.attach(label_list, 0, 5, 1, 1)
-            self.grid.attach(parents_view, 1, 5, 4, 3)
+        self.grid.attach(label_list, 0, 5, 1, 1)
+        self.grid.attach(parents_view, 1, 5, 4, 3)
 
-            for ftype, free in self.free_info:
-                if ftype == "lvmpv":
-                    pv = free.parents[0]
-                    parents_store.append([pv, free, False, pv.name, "lvmpv", str(free.size)])
-                else:
-                    disk = free.parents[0]
-                    parents_store.append([disk, free, False, disk.name, "free region", str(free.size)])
+        for ftype, free in self.free_info:
+            if ftype == "lvmpv":
+                pv = free.parents[0]
+                parents_store.append([pv, free, False, pv.name, "lvmpv", str(free.size)])
+            else:
+                disk = free.parents[0]
+                parents_store.append([disk, free, False, disk.name, "free region", str(free.size)])
 
-            self.widgets_dict["add"] = [label_list, parents_view]
+        return parents_store
 
-            return parents_store
-
-    def on_cell_toggled(self, _toggle, path, store):
+    def _on_cell_toggled(self, _toggle, path, store):
         store[path][2] = not store[path][2]
 
-    def on_cell_radio_toggled(self, _toggle, path, store):
-        for row in store:
-            row[2] = (row.path == Gtk.TreePath(path))
+    def get_selection(self):
 
-    def remove_parents(self):
+        parents_list = []
 
-        # get removable pvs
-        removable_pvs = [pv for pv in self.edited_device.pvs if (pv.size // self.edited_device.pe_size) <= self.edited_device.free_extents]
+        if self.add_store:
+            for row in self.add_store:
+                if row[2] and row[0].type == "partition":
+                    parents_list.append(row[0])
+
+                if row[2] and row[0].type == "disk":
+                    parents_list.append(row[1])
+
+        return ProxyDataContainer(edit_device=self.edited_device,
+                                  action_type="add",
+                                  parents_list=parents_list)
+
+
+class LVMRemoveDialog(Gtk.Dialog):
+    """ Dialog window allowing user to remove parents from a VG
+    """
+
+    def __init__(self, parent_window, edited_device):
+        """
+
+            :param parent_window: parent window
+            :type parent_window: Gtk.Window
+            :param edited_device: device selected to edit
+            :type edited_device: class blivet.Device
+
+        """
+
+        self.edited_device = edited_device
+        self.parent_window = parent_window
+
+        Gtk.Dialog.__init__(self)
+
+        self.set_transient_for(self.parent_window)
+        self.set_resizable(False)
+        self.set_title(_("Remove parent device"))
+        self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                         Gtk.STOCK_OK, Gtk.ResponseType.OK)
+
+        self.grid = Gtk.Grid(column_homogeneous=False, row_spacing=10, column_spacing=5)
+        self.grid.set_border_width(10)
+
+        box = self.get_content_area()
+        box.add(self.grid)
+
+        self._add_parent_list()
+        self.remove_store = self._add_removable_parents()
+
+        self.show_all()
+
+    def _add_parent_list(self):
+
+        parents_store = Gtk.ListStore(str, str, str)
+
+        for parent in self.edited_device.parents:
+            parents_store.append([parent.name, "lvmpv", str(parent.size)])
+
+        parents_view = Gtk.TreeView(model=parents_store)
+        renderer_text = Gtk.CellRendererText()
+
+        column_name = Gtk.TreeViewColumn(_("Device"), renderer_text, text=0)
+        column_type = Gtk.TreeViewColumn(_("Type"), renderer_text, text=1)
+        column_size = Gtk.TreeViewColumn(_("Size"), renderer_text, text=2)
+
+        parents_view.append_column(column_name)
+        parents_view.append_column(column_type)
+        parents_view.append_column(column_size)
+
+        parents_view.set_headers_visible(True)
+
+        label_list = Gtk.Label(label=_("Parent devices:"), xalign=1)
+
+        self.grid.attach(label_list, 0, 1, 1, 1)
+        self.grid.attach(parents_view, 1, 1, 3, 3)
+
+    def _add_removable_parents(self):
+
+        removable_pvs = [pv for pv in self.edited_device.pvs
+                         if (pv.size // self.edited_device.pe_size) <= self.edited_device.free_extents]
 
         if len(removable_pvs) == 0:
             label_none = Gtk.Label(label=_("There isn't a physical volume that could be\n"
                                            "removed from this volume group."))
             self.grid.attach(label_none, 0, 5, 4, 1)
 
-            self.widgets_dict["remove"] = [label_none]
-
             return None
 
-        else:
-            parents_store = Gtk.ListStore(object, object, bool, str, str, str)
-            parents_view = Gtk.TreeView(model=parents_store)
+        parents_store = Gtk.ListStore(object, object, bool, str, str, str)
+        parents_view = Gtk.TreeView(model=parents_store)
 
-            parents_view.set_tooltip_text(_("Currently it is possible to remove only one parent at time."))
+        parents_view.set_tooltip_text(_("Currently it is possible to remove only one parent at time."))
 
-            renderer_radio = Gtk.CellRendererToggle()
-            renderer_radio.connect("toggled", self.on_cell_radio_toggled, parents_store)
-            renderer_radio.set_radio(True)
+        renderer_radio = Gtk.CellRendererToggle()
+        renderer_radio.connect("toggled", self._on_cell_radio_toggled, parents_store)
+        renderer_radio.set_radio(True)
 
-            renderer_text = Gtk.CellRendererText()
+        renderer_text = Gtk.CellRendererText()
 
-            column_radio = Gtk.TreeViewColumn(_("Remove?"), renderer_radio, active=2)
-            column_name = Gtk.TreeViewColumn(_("Device"), renderer_text, text=3)
-            column_type = Gtk.TreeViewColumn(_("Type"), renderer_text, text=4)
-            column_size = Gtk.TreeViewColumn(_("Size"), renderer_text, text=5)
+        column_radio = Gtk.TreeViewColumn(_("Remove?"), renderer_radio, active=2)
+        column_name = Gtk.TreeViewColumn(_("Device"), renderer_text, text=3)
+        column_type = Gtk.TreeViewColumn(_("Type"), renderer_text, text=4)
+        column_size = Gtk.TreeViewColumn(_("Size"), renderer_text, text=5)
 
-            parents_view.append_column(column_radio)
-            parents_view.append_column(column_name)
-            parents_view.append_column(column_type)
-            parents_view.append_column(column_size)
+        parents_view.append_column(column_radio)
+        parents_view.append_column(column_name)
+        parents_view.append_column(column_type)
+        parents_view.append_column(column_size)
 
-            parents_view.set_headers_visible(True)
+        parents_view.set_headers_visible(True)
 
-            label_list = Gtk.Label(label=_("Available devices:"), xalign=1)
+        label_list = Gtk.Label(label=_("Available devices:"), xalign=1)
 
-            self.grid.attach(label_list, 0, 5, 1, 1)
-            self.grid.attach(parents_view, 1, 5, 4, 3)
+        self.grid.attach(label_list, 0, 5, 1, 1)
+        self.grid.attach(parents_view, 1, 5, 4, 3)
 
-            for pv in removable_pvs:
-                parents_store.append([pv, None, False, pv.name, "lvmpv", str(pv.size)])
+        for pv in removable_pvs:
+            parents_store.append([pv, None, False, pv.name, "lvmpv", str(pv.size)])
 
-            self.widgets_dict["remove"] = [label_list, parents_view]
+        return parents_store
 
-            return parents_store
-
-    def on_button_toggled(self, clicked_button, button_type, other_button):
-
-        if clicked_button.get_active():
-            other_button.set_active(False)
-            self.show_widgets([button_type])
-
-        else:
-            self.hide_widgets([button_type])
-
-    def show_widgets(self, widget_types):
-
-        for widget_type in widget_types:
-            for widget in self.widgets_dict[widget_type]:
-                widget.show()
-
-    def hide_widgets(self, widget_types):
-
-        for widget_type in widget_types:
-            for widget in self.widgets_dict[widget_type]:
-                widget.hide()
+    def _on_cell_radio_toggled(self, _toggle, path, store):
+        for row in store:
+            row[2] = (row.path == Gtk.TreePath(path))
 
     def get_selection(self):
 
         parents_list = []
 
-        if self.button_add.get_active():
-            action_type = "add"
-
-            if self.add_store:
-                for row in self.add_store:
-                    if row[2] and row[0].type == "partition":
-                        parents_list.append(row[0])
-
-                    if row[2] and row[0].type == "disk":
-                        parents_list.append(row[1])
-
-        elif self.button_remove.get_active():
-            action_type = "remove"
-            if self.remove_store:
-                for row in self.remove_store:
-                    if row[2]:
-                        parents_list.append(row[0])
-
-        else:
-            action_type = None
+        if self.remove_store:
+            for row in self.remove_store:
+                if row[2]:
+                    parents_list.append(row[0])
 
         return ProxyDataContainer(edit_device=self.edited_device,
-                                  action_type=action_type,
+                                  action_type="remove",
                                   parents_list=parents_list)

--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -345,7 +345,7 @@ class ListPartitions:
             self.blivet_gui.activate_device_actions(["open"])
 
         if device.type == "lvmvg":
-            self.blivet_gui.activate_device_actions(["parents"])
+            self.blivet_gui.activate_device_actions(["add_parent", "remove_parent"])
 
         if device.format:
             if device.format.type == "luks" and not device.format.status and device.format.exists:

--- a/data/ui/blivet-gui.ui
+++ b/data/ui/blivet-gui.ui
@@ -74,10 +74,18 @@
               </object>
             </child>
             <child>
-              <object class="GtkMenuItem" id="menuitem_parents">
+              <object class="GtkMenuItem" id="menuitem_add_parent">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Modify parents</property>
+                <property name="label" translatable="yes">Add parent</property>
+                <property name="use-underline">True</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="menuitem_remove_parent">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Remove parent</property>
                 <property name="use-underline">True</property>
               </object>
             </child>
@@ -162,10 +170,18 @@
       </object>
     </child>
     <child>
-      <object class="GtkMenuItem" id="button_parents">
+      <object class="GtkMenuItem" id="button_add_parent">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Modify parents</property>
+        <property name="label" translatable="yes">Add parent</property>
+        <property name="use-underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="button_remove_parent">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Remove parent</property>
         <property name="use-underline">True</property>
       </object>
     </child>

--- a/tests/blivetgui_tests/edit_dialog_test.py
+++ b/tests/blivetgui_tests/edit_dialog_test.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from blivet.size import Size
 
-from blivetgui.dialogs.edit_dialog import FormatDialog, MountpointDialog, LabelDialog, UnmountDialog, ResizeDialog, LVMEditDialog, RenameDialog
+from blivetgui.dialogs.edit_dialog import FormatDialog, MountpointDialog, LabelDialog, UnmountDialog, ResizeDialog, LVMAddDialog, LVMRemoveDialog, RenameDialog
 from blivetgui.i18n import _
 
 from .add_dialog_test import supported_filesystems
@@ -458,7 +458,7 @@ class RenameDialogTest(unittest.TestCase):
 
 
 @unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
-class LVMEditDialogTest(unittest.TestCase):
+class LVMAddDialogTest(unittest.TestCase):
 
     error_dialog = MagicMock()
 
@@ -475,62 +475,39 @@ class LVMEditDialogTest(unittest.TestCase):
         cls.parent_window.destroy()
 
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
-    def test_no_free_space_for_add(self):
-        """Test LVMEditDialog when there's no free space to add parents"""
+    def test_no_free_space(self):
+        """Test LVMAddDialog when there's no free space to add parents"""
 
-        # create mock VG with existing PVs (configure mock attributes properly)
         pv1 = MagicMock()
         pv1.configure_mock(name="pv1", size=Size("1 GiB"))
         vg = MagicMock()
         vg.configure_mock(name="testvg", parents=[pv1], pvs=[pv1], free_extents=0, pe_size=Size("4 MiB"))
 
-        dialog = LVMEditDialog(self.parent_window, vg, free_info=[])
+        dialog = LVMAddDialog(self.parent_window, vg, free_info=[])
 
-        # should show "no empty physical volumes" message
         self.assertIsNone(dialog.add_store)
-        self.assertIn("add", dialog.widgets_dict)
-        self.assertEqual(len(dialog.widgets_dict["add"]), 1)
-
-    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
-    def test_no_removable_pvs(self):
-        """Test LVMEditDialog when there are no removable PVs"""
-
-        # create mock VG where all PVs are in use
-        pv1 = MagicMock()
-        pv1.configure_mock(name="pv1", size=Size("1 GiB"))
-        vg = MagicMock()
-        vg.configure_mock(name="testvg", parents=[pv1], pvs=[pv1], free_extents=0, pe_size=Size("4 MiB"))
-
-        dialog = LVMEditDialog(self.parent_window, vg, free_info=[])
-
-        # should show "no removable PVs" message
-        self.assertIsNone(dialog.remove_store)
-        self.assertIn("remove", dialog.widgets_dict)
-        self.assertEqual(len(dialog.widgets_dict["remove"]), 1)
 
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_add_parents_available(self):
-        """Test LVMEditDialog with available devices to add"""
+        """Test LVMAddDialog with available devices to add"""
 
         pv1 = MagicMock()
         pv1.configure_mock(name="pv1", size=Size("1 GiB"))
         vg = MagicMock()
         vg.configure_mock(name="testvg", parents=[pv1], pvs=[pv1], free_extents=100, pe_size=Size("4 MiB"))
 
-        # mock available free space
         new_pv = MagicMock()
         new_pv.configure_mock(name="pv2", type="partition")
         free_region = MagicMock()
         free_region.configure_mock(parents=[new_pv], size=Size("1 GiB"))
         free_info = [("lvmpv", free_region)]
 
-        dialog = LVMEditDialog(self.parent_window, vg, free_info=free_info)
+        dialog = LVMAddDialog(self.parent_window, vg, free_info=free_info)
 
-        # should have add_store with one row
         self.assertIsNotNone(dialog.add_store)
         self.assertEqual(len(dialog.add_store), 1)
-        self.assertEqual(dialog.add_store[0][3], "pv2")  # device name
-        self.assertFalse(dialog.add_store[0][2])  # initially not selected
+        self.assertEqual(dialog.add_store[0][3], "pv2")
+        self.assertFalse(dialog.add_store[0][2])
 
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_add_disk_free_region(self):
@@ -541,54 +518,23 @@ class LVMEditDialogTest(unittest.TestCase):
         vg = MagicMock()
         vg.configure_mock(name="testvg", parents=[pv1], pvs=[pv1], free_extents=100, pe_size=Size("4 MiB"))
 
-        # mock free region on a disk
         disk = MagicMock()
         disk.configure_mock(name="sda", type="disk")
         free_region = MagicMock()
         free_region.configure_mock(parents=[disk], size=Size("5 GiB"))
         free_info = [("disk", free_region)]
 
-        dialog = LVMEditDialog(self.parent_window, vg, free_info=free_info)
+        dialog = LVMAddDialog(self.parent_window, vg, free_info=free_info)
 
-        # should have add_store with disk free region
         self.assertIsNotNone(dialog.add_store)
         self.assertEqual(len(dialog.add_store), 1)
-        self.assertEqual(dialog.add_store[0][3], "sda")  # disk name
-        self.assertEqual(dialog.add_store[0][4], "free region")  # type
-
-    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
-    def test_toggle_buttons(self):
-        """Test add/remove toggle buttons in LVMEditDialog"""
-
-        pv1 = MagicMock()
-        pv1.configure_mock(name="pv1", size=Size("1 GiB"))
-        pv2 = MagicMock()
-        pv2.configure_mock(name="pv2", size=Size("1 GiB"))
-        vg = MagicMock()
-        vg.configure_mock(name="testvg", parents=[pv1, pv2], pvs=[pv1, pv2],
-                          free_extents=260, pe_size=Size("4 MiB"))
-
-        new_pv = MagicMock()
-        new_pv.configure_mock(name="pv3", type="partition")
-        free_region = MagicMock()
-        free_region.configure_mock(parents=[new_pv], size=Size("1 GiB"))
-        free_info = [("lvmpv", free_region)]
-
-        dialog = LVMEditDialog(self.parent_window, vg, free_info=free_info)
-
-        # toggle add button
-        dialog.button_add.set_active(True)
-        self.assertTrue(dialog.button_add.get_active())
-        self.assertFalse(dialog.button_remove.get_active())
-
-        # toggle remove button
-        dialog.button_remove.set_active(True)
-        self.assertTrue(dialog.button_remove.get_active())
-        self.assertFalse(dialog.button_add.get_active())
+        self.assertEqual(dialog.add_store[0][3], "sda")
+        self.assertEqual(dialog.add_store[0][4], "free region")
 
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_get_selection(self):
-        # adding
+        """Test get_selection returns correct add selection"""
+
         pv1 = MagicMock()
         pv1.configure_mock(name="pv1", size=Size("1 GiB"))
         vg = MagicMock()
@@ -600,11 +546,9 @@ class LVMEditDialogTest(unittest.TestCase):
         free_region.configure_mock(parents=[pv2], size=Size("1 GiB"))
         free_info = [("lvmpv", free_region)]
 
-        dialog = LVMEditDialog(self.parent_window, vg, free_info=free_info)
+        dialog = LVMAddDialog(self.parent_window, vg, free_info=free_info)
 
-        # activate add button and select a device
-        dialog.button_add.set_active(True)
-        dialog.add_store[0][2] = True  # select first device
+        dialog.add_store[0][2] = True
 
         selection = dialog.get_selection()
         self.assertEqual(selection.edit_device, vg)
@@ -612,15 +556,69 @@ class LVMEditDialogTest(unittest.TestCase):
         self.assertEqual(len(selection.parents_list), 1)
         self.assertEqual(selection.parents_list[0].name, "pv2")
 
-        # removing
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class LVMRemoveDialogTest(unittest.TestCase):
+
+    error_dialog = MagicMock()
+
+    @classmethod
+    def setUpClass(cls):
+        import gi
+        gi.require_version("Gtk", "3.0")
+        from gi.repository import Gtk
+
+        cls.parent_window = Gtk.Window()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.parent_window.destroy()
+
+    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
+    def test_no_removable_pvs(self):
+        """Test LVMRemoveDialog when there are no removable PVs"""
+
+        pv1 = MagicMock()
+        pv1.configure_mock(name="pv1", size=Size("1 GiB"))
+        vg = MagicMock()
+        vg.configure_mock(name="testvg", parents=[pv1], pvs=[pv1], free_extents=0, pe_size=Size("4 MiB"))
+
+        dialog = LVMRemoveDialog(self.parent_window, vg)
+
+        self.assertIsNone(dialog.remove_store)
+
+    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
+    def test_removable_pvs_available(self):
+        """Test LVMRemoveDialog with removable PVs"""
+
+        pv1 = MagicMock()
+        pv1.configure_mock(name="pv1", size=Size("1 GiB"))
+        pv2 = MagicMock()
+        pv2.configure_mock(name="pv2", size=Size("1 GiB"))
+        vg = MagicMock()
         vg.configure_mock(name="testvg", parents=[pv1, pv2], pvs=[pv1, pv2],
                           free_extents=260, pe_size=Size("4 MiB"))
 
-        dialog = LVMEditDialog(self.parent_window, vg, free_info=[])
+        dialog = LVMRemoveDialog(self.parent_window, vg)
 
-        # activate remove button and select a device
-        dialog.button_remove.set_active(True)
-        dialog.remove_store[0][2] = True  # select first device
+        self.assertIsNotNone(dialog.remove_store)
+        self.assertEqual(len(dialog.remove_store), 2)
+
+    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
+    def test_get_selection(self):
+        """Test get_selection returns correct remove selection"""
+
+        pv1 = MagicMock()
+        pv1.configure_mock(name="pv1", size=Size("1 GiB"))
+        pv2 = MagicMock()
+        pv2.configure_mock(name="pv2", size=Size("1 GiB"))
+        vg = MagicMock()
+        vg.configure_mock(name="testvg", parents=[pv1, pv2], pvs=[pv1, pv2],
+                          free_extents=260, pe_size=Size("4 MiB"))
+
+        dialog = LVMRemoveDialog(self.parent_window, vg)
+
+        dialog.remove_store[0][2] = True
 
         selection = dialog.get_selection()
         self.assertEqual(selection.edit_device, vg)

--- a/tests/blivetgui_tests/edit_dialog_test.py
+++ b/tests/blivetgui_tests/edit_dialog_test.py
@@ -556,6 +556,54 @@ class LVMAddDialogTest(unittest.TestCase):
         self.assertEqual(len(selection.parents_list), 1)
         self.assertEqual(selection.parents_list[0].name, "pv2")
 
+    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
+    def test_get_selection_disk_free_region(self):
+        """Test get_selection with a disk free region selected"""
+
+        pv1 = MagicMock()
+        pv1.configure_mock(name="pv1", size=Size("1 GiB"))
+        vg = MagicMock()
+        vg.configure_mock(name="testvg", parents=[pv1], pvs=[pv1], free_extents=100, pe_size=Size("4 MiB"))
+
+        disk = MagicMock()
+        disk.configure_mock(name="sda", type="disk")
+        free_region = MagicMock()
+        free_region.configure_mock(parents=[disk], size=Size("5 GiB"))
+        free_info = [("disk", free_region)]
+
+        dialog = LVMAddDialog(self.parent_window, vg, free_info=free_info)
+
+        dialog.add_store[0][2] = True
+
+        selection = dialog.get_selection()
+        self.assertEqual(selection.action_type, "add")
+        self.assertEqual(len(selection.parents_list), 1)
+        self.assertIs(selection.parents_list[0], free_region)
+
+    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
+    def test_get_selection_lvmpv_on_disk(self):
+        """Test get_selection with an lvmpv backed by a disk"""
+
+        pv1 = MagicMock()
+        pv1.configure_mock(name="pv1", size=Size("1 GiB"))
+        vg = MagicMock()
+        vg.configure_mock(name="testvg", parents=[pv1], pvs=[pv1], free_extents=100, pe_size=Size("4 MiB"))
+
+        disk_pv = MagicMock()
+        disk_pv.configure_mock(name="sdb", type="disk", size=Size("10 GiB"))
+        free_region = MagicMock()
+        free_region.configure_mock(parents=[disk_pv], size=Size("10 GiB"))
+        free_info = [("lvmpv", free_region)]
+
+        dialog = LVMAddDialog(self.parent_window, vg, free_info=free_info)
+
+        dialog.add_store[0][2] = True
+
+        selection = dialog.get_selection()
+        self.assertEqual(selection.action_type, "add")
+        self.assertEqual(len(selection.parents_list), 1)
+        self.assertIs(selection.parents_list[0], disk_pv)
+
 
 @unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
 class LVMRemoveDialogTest(unittest.TestCase):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate **“Add parent”** and **“Remove parent”** options for LVM Volume Group parent device management in both the menu and toolbar.

* **Refactor**
  * Replaced the combined parent-editing UI with dedicated dialogs for adding and removing parent devices, with updated selection behavior.

* **Tests**
  * Updated dialog tests to cover the new add/remove dialog flows and selection outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->