### PR TITLE
spec: List dependency on libblockdev plugins separately

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -18,7 +18,17 @@ BuildRequires: libappstream-glib
 Requires: blivet-gui-runtime = %{version}-%{release}
 Requires: PolicyKit-authentication-agent
 Requires: polkit
-Requires: libblockdev-plugins-all
+Requires: libblockdev-swap
+Requires: libblockdev-mdraid
+Requires: libblockdev-loop
+Requires: libblockdev-fs
+Requires: libblockdev-dm
+Requires: libblockdev-crypto
+Requires: libblockdev-btrfs
+Requires: libblockdev-lvm-dbus
+Requires: libblockdev-mpath
+Requires: libblockdev-nvme
+Requires: libblockdev-part
 
 %description
 Graphical (GTK) tool for manipulation and configuration of data storage


### PR DESCRIPTION
We don't need all libblockdev plugins so using the plugins-all metapackage bring in some plugins we don't need. The plugins listed here now are all plugins required by blivet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency requirements to list individual storage-related components instead of one bundled dependency.
  * This makes installation and build requirements more explicit and precise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->