### PR TITLE
misc: Use ansible_facts instead of deprecated top-level fact variables

### DIFF
--- a/misc/blivet-gui-tasks.yml
+++ b/misc/blivet-gui-tasks.yml
@@ -16,7 +16,7 @@
       - python3-pid
       - make
       - python3-sphinx
-  when: ansible_distribution == "Fedora"
+  when: ansible_facts['distribution'] == "Fedora"
 
 - name: Install test dependencies (Fedora)
   package:
@@ -34,12 +34,12 @@
       - dosfstools
       - e2fsprogs
       - xfsprogs
-  when: ansible_distribution == "Fedora"
+  when: ansible_facts['distribution'] == "Fedora"
 
 - name: Update apt cache (Debian/Ubuntu)
   apt:
     update_cache: yes
-  when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
+  when: ansible_facts['distribution'] == "Debian" or ansible_facts['distribution'] == "Ubuntu"
 
 - name: Install runtime and build dependencies (Ubuntu/Debian)
   package:
@@ -51,7 +51,7 @@
       - dh-python
       - python3-gi-cairo
       - gir1.2-gtk-3.0
-  when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
+  when: ansible_facts['distribution'] == "Ubuntu" or ansible_facts['distribution'] == "Debian"
 
 - name: Install test dependencies (Ubuntu/Debian)
   package:
@@ -71,7 +71,7 @@
       - dosfstools
       - e2fsprogs
       - xfsprogs
-  when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
+  when: ansible_facts['distribution'] == "Ubuntu" or ansible_facts['distribution'] == "Debian"
 
 - name: Install Blivet dependencies not covered by PyPI (Ubuntu/Debian)
   package:
@@ -91,14 +91,14 @@
       - libblockdev-dm3
       - libblockdev-mdraid3
       - libblockdev-fs3
-  when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
+  when: ansible_facts['distribution'] == "Ubuntu" or ansible_facts['distribution'] == "Debian"
 
 # pocketlint, blivet and pid is not packaged on Ubuntu/Debian
 - name: Install pocketlint, blivet and pid using pip (Ubuntu/Debian)
   pip:
     name: ['pocketlint', 'blivet', 'pid']
     extra_args: --break-system-packages
-  when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
+  when: ansible_facts['distribution'] == "Ubuntu" or ansible_facts['distribution'] == "Debian"
 
 - name: Install runtime and build dependencies (OpenSUSE)
   package:
@@ -115,7 +115,7 @@
       - gobject-introspection
       - python3-gobject-Gdk
       - typelib-1_0-Gtk-3_0
-  when: ansible_os_family == "Suse"
+  when: ansible_facts['os_family'] == "Suse"
 
 - name: Install test dependencies (openSUSE)
   package:
@@ -133,7 +133,7 @@
       - e2fsprogs
       - xfsprogs
       - adwaita-icon-theme
-  when: ansible_os_family == "Suse"
+  when: ansible_facts['os_family'] == "Suse"
 
 - name: Install Blivet dependencies not covered by PyPI (openSUSE)
   package:
@@ -157,11 +157,11 @@
       - libbd_mpath3
       - libbd_swap3
       - libbd_utils3
-  when: ansible_os_family == "Suse"
+  when: ansible_facts['os_family'] == "Suse"
 
 # pocketlint, blivet and pid is not packaged on openSUSE
 - name: Install pocketlint, blivet and pid using pip (openSUSE)
   pip:
     name: ['pocketlint', 'blivet', 'pid']
     extra_args: --break-system-packages
-  when: ansible_os_family == "Suse"
+  when: ansible_facts['os_family'] == "Suse"


### PR DESCRIPTION
Ansible deprecated the injected top-level ansible_* fact variables (e.g. ansible_distribution) in favour of accessing them through the ansible_facts dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved operating system detection during automated setup.
  - Dependency and package installation tasks now work reliably across Fedora, Debian/Ubuntu, and openSUSE environments.
  - Preserved existing package selections and installation conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->