### PR TITLE
Fix RenameDialog treating window-close/Escape as a confirmed rename

### DIFF
--- a/blivetgui/dialogs/edit_dialog.py
+++ b/blivetgui/dialogs/edit_dialog.py
@@ -494,16 +494,16 @@ class RenameDialog:
     def run(self):
         response = self.dialog.run()
 
-        if response == Gtk.ResponseType.REJECT:
-            self.dialog.destroy()
-            return ProxyDataContainer(edit_device=self.edit_device, rename=False, name=None)
-        else:
+        if response == Gtk.ResponseType.ACCEPT:
             new_name = self.entry_rename.get_text()
             if not self._validate_user_input(new_name):
                 return self.run()
             else:
                 self.dialog.destroy()
                 return ProxyDataContainer(edit_device=self.edit_device, rename=True, name=new_name)
+        else:
+            self.dialog.destroy()
+            return ProxyDataContainer(edit_device=self.edit_device, rename=False, name=None)
 
     def _on_cancel_button(self, _button):
         self.dialog.response(Gtk.ResponseType.REJECT)


### PR DESCRIPTION
RenameDialog.run() only treated an explicit REJECT response as a cancel and used the else branch (which reads the entry and performs the rename) for everything else. Closing the dialog with the window's X button or pressing Escape emits DELETE_EVENT, which fell into that else branch and was treated as a confirmed rename -- either trapping the user in a re-run loop on invalid input or scheduling an unintended rename.

Check for an explicit ACCEPT response instead, matching the convention used by the other dialogs in this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rename dialog behavior so accepted actions complete the rename, while other responses cancel correctly.
  * Invalid names continue to prompt for correction instead of closing the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->