### PR TITLE
Makefile: don't use -K for ansible unless needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ RELEASE_TAG=$(VERSION)
 
 PYTHON=python3
 
+ANSIBLE_BECOME_FLAG := $(shell [ "$$(id -u)" -eq 0 ] && echo "" || echo "-K")
+
 all:
 	$(MAKE) -C po
 
@@ -15,7 +17,7 @@ potfile:
 install-requires:
 	@echo "*** Installing the dependencies required for testing and analysis ***"
 	@which ansible-playbook >/dev/null 2>&1 || ( echo "Please install Ansible to install testing dependencies"; exit 1 )
-	@ansible-playbook -K -i "localhost," -c local misc/install-test-dependencies.yml
+	@ansible-playbook $(ANSIBLE_BECOME_FLAG) -i "localhost," -c local misc/install-test-dependencies.yml
 
 test:
 	@echo "*** Running unittests ***"


### PR DESCRIPTION
When you run `make install-requires` it will prompt you for the BECOMING password which isn't needed if you're already running as root.

See also https://github.com/storaged-project/blivet/commit/66c8a2b7821d22a8ae72c7d8e38e230684d5c23e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test dependencies can now be installed correctly when running as root, without requiring unnecessary privilege escalation.
  * Non-root installations continue to use privilege escalation as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->